### PR TITLE
Remove promises / trycatch

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,16 @@ const app = new Koa();
 app.use(bodyParser());
 app.use(cors());
 
+// better error handling
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (err) {
+    ctx.status = err.status || 500;
+    ctx.body = { errors: [err] };
+    ctx.app.emit('error', err, ctx);
+  }
+});
 
 app.use(v1Routes.routes());
 

--- a/routes/v1/index.js
+++ b/routes/v1/index.js
@@ -1,9 +1,11 @@
 const Router = require('koa-router');
 const layerGroups = require('./layer-groups');
+const sources = require('./sources');
 
 const router = new Router();
 
 router.use('/v1/layer-groups', layerGroups.routes());
+router.use('/v1/sources', sources.routes());
 
 router.get('/v1', async (ctx) => {
   ctx.body = {

--- a/routes/v1/sources.js
+++ b/routes/v1/sources.js
@@ -1,5 +1,4 @@
 const Router = require('koa-router');
-const buildMapboxStyle = require('../../utils/build-mapbox-style');
 const { where } = require('../../utils/local-resources-utilities');
 
 const router = new Router();
@@ -13,14 +12,11 @@ router.get('/', async (ctx) => {
 
 router.post('/', async (ctx) => {
   const config = ctx.request.body;
-  const { 'layer-groups': ids } = config;
+  const { sources: ids } = config;
 
-  const data = await where('layer-groups', { id: ids });
-  const meta = {
-    mapboxStyle: await buildMapboxStyle(data),
-  };
+  const data = await where('sources', { id: ids });
 
-  ctx.body = { data, meta };
+  ctx.body = { data };
 });
 
 module.exports = router;

--- a/utils/build-mapbox-style.js
+++ b/utils/build-mapbox-style.js
@@ -3,53 +3,49 @@ const unique = require('array-unique');
 const { where } = require('./local-resources-utilities');
 const structureCartoSource = require('./structure-carto-source');
 
-const buildLayerGroups = layerGroups => new Promise(async (resolve, reject) => {
-  try {
-    // import the base style from labs-gl-style repo on github
-    const baseStyle = await fetch('https://raw.githubusercontent.com/NYCPlanning/labs-gl-style/master/data/style.json')
-      .then(d => d.json());
+const buildLayerGroups = layerGroups => new Promise(async (resolve) => {
+  // import the base style from labs-gl-style repo on github
+  const baseStyle = await fetch('https://raw.githubusercontent.com/NYCPlanning/labs-gl-style/master/data/style.json')
+    .then(d => d.json());
 
-    // iterate over configs, pull out the layers and all required source ids
-    let layers = [];
-    let sourceIds = [];
+  // iterate over configs, pull out the layers and all required source ids
+  let layers = [];
+  let sourceIds = [];
 
-    layerGroups.forEach((layerGroupConfig) => {
-      const internalLayers = layerGroupConfig.layers.map(d => d.layer);
-      const internalSourceIds = internalLayers.map(d => d.source);
-      layers = [...layers, ...internalLayers];
-      sourceIds = [...sourceIds, ...internalSourceIds];
+  layerGroups.forEach((layerGroupConfig) => {
+    const internalLayers = layerGroupConfig.layers.map(d => d.layer);
+    const internalSourceIds = internalLayers.map(d => d.source);
+    layers = [...layers, ...internalLayers];
+    sourceIds = [...sourceIds, ...internalSourceIds];
+  });
+
+  // add all layers to the baseStyle
+  // TODO use the order of the layers specified in the config to determine the correct order
+  // TODO set visibility for each layer
+  // TODO insert before labels
+  baseStyle.layers = [...baseStyle.layers, ...layers];
+
+  // de-dupe source ids, many layers may require the same source
+  sourceIds = unique(sourceIds);
+
+  // get sources for each id
+  const sources = await where('sources', { id: sourceIds });
+  const structuredSources = await Promise.all(
+    sources.map(
+      source => structureCartoSource(source),
+    ),
+  );
+
+  // add all sources to the base style
+  structuredSources
+    .forEach(async (source) => {
+      baseStyle.sources = {
+        ...baseStyle.sources,
+        ...source,
+      };
     });
 
-    // add all layers to the baseStyle
-    // TODO use the order of the layers specified in the config to determine the correct order
-    // TODO set visibility for each layer
-    // TODO insert before labels
-    baseStyle.layers = [...baseStyle.layers, ...layers];
-
-    // de-dupe source ids, many layers may require the same source
-    sourceIds = unique(sourceIds);
-
-    // get sources for each id
-    const sources = await where('sources', { id: sourceIds });
-    const structuredSources = await Promise.all(
-      sources.map(
-        source => structureCartoSource(source),
-      ),
-    );
-
-    // add all sources to the base style
-    structuredSources
-      .forEach(async (source) => {
-        baseStyle.sources = {
-          ...baseStyle.sources,
-          ...source,
-        };
-      });
-
-    resolve(baseStyle);
-  } catch (e) {
-    reject(e);
-  }
+  resolve(baseStyle);
 });
 
 module.exports = buildLayerGroups;

--- a/utils/build-mapbox-style.js
+++ b/utils/build-mapbox-style.js
@@ -3,7 +3,7 @@ const unique = require('array-unique');
 const { where } = require('./local-resources-utilities');
 const structureCartoSource = require('./structure-carto-source');
 
-const buildLayerGroups = layerGroups => new Promise(async (resolve) => {
+module.exports = async (layerGroups) => {
   // import the base style from labs-gl-style repo on github
   const baseStyle = await fetch('https://raw.githubusercontent.com/NYCPlanning/labs-gl-style/master/data/style.json')
     .then(d => d.json());
@@ -38,14 +38,12 @@ const buildLayerGroups = layerGroups => new Promise(async (resolve) => {
 
   // add all sources to the base style
   structuredSources
-    .forEach(async (source) => {
+    .forEach((source) => {
       baseStyle.sources = {
         ...baseStyle.sources,
         ...source,
       };
     });
 
-  resolve(baseStyle);
-});
-
-module.exports = buildLayerGroups;
+  return baseStyle;
+};

--- a/utils/structure-carto-source.js
+++ b/utils/structure-carto-source.js
@@ -1,21 +1,15 @@
 const carto = require('./carto');
 
-const getSource = sourceConfig => new Promise(async (resolve, reject) => {
-  try {
-    // instantiate carto vector tiles, get back the tile template
-    const template = await carto.getVectorTileTemplate(sourceConfig['source-layers']);
+module.exports = async (sourceConfig) => {
+  // instantiate carto vector tiles, get back the tile template
+  const template = await carto.getVectorTileTemplate(sourceConfig['source-layers']);
 
-    // make an object with sourceid as a key, and valid mapboxGL source as value
-    const source = {};
-    source[sourceConfig.id] = {
-      type: 'vector',
-      tiles: [template],
-    };
+  // make an object with sourceid as a key, and valid mapboxGL source as value
+  const source = {};
+  source[sourceConfig.id] = {
+    type: 'vector',
+    tiles: [template],
+  };
 
-    resolve(source);
-  } catch (e) {
-    reject(e);
-  }
-});
-
-module.exports = getSource;
+  return source;
+};


### PR DESCRIPTION
Some of our utilities were using promises and try / catch, but since Koa is a single promise chain, we can rely on bubbling to a general error handler. 