### PR TITLE
add metadata and visibility

### DIFF
--- a/test/acceptance/routes.layer-group.test.js
+++ b/test/acceptance/routes.layer-group.test.js
@@ -320,4 +320,55 @@ describe('POST /layer-groups', () => {
         done();
       });
   });
+
+  it('appends layergroup metadata to layers', (done) => {
+    chai.request(server)
+      .post('/v1/layer-groups')
+      .set('content-type', 'application/json')
+      .send({
+        'layer-groups': [
+          {
+            id: 'zoning-districts',
+          },
+        ],
+      })
+      .end((err, res) => {
+        const { meta, errors } = res.body;
+
+        expect(errors).to.equal(undefined);
+
+        const zdLayers = meta.mapboxStyle.layers
+          .filter(d => (d.metadata && d.metadata['nycplanninglabs:layergroupid'] === 'zoning-districts'));
+        expect(zdLayers.length).to.equal(3);
+
+        done();
+      });
+  });
+
+  it('sets visibility of child layers to match layerGroup visible property', (done) => {
+    chai.request(server)
+      .post('/v1/layer-groups')
+      .set('content-type', 'application/json')
+      .send({
+        'layer-groups': [
+          {
+            id: 'zoning-districts',
+            visible: 'false',
+          },
+        ],
+      })
+      .end((err, res) => {
+        const { meta, errors } = res.body;
+        const zdLayers = meta.mapboxStyle.layers
+          .filter(d => (d.metadata && d.metadata['nycplanninglabs:layergroupid'] === 'zoning-districts'));
+        expect(zdLayers[0].visibility).to.equal('none');
+        expect(zdLayers[1].visibility).to.equal('none');
+        expect(zdLayers[2].visibility).to.equal('none');
+
+        expect(errors).to.equal(undefined);
+
+
+        done();
+      });
+  });
 });

--- a/utils/build-mapbox-style.js
+++ b/utils/build-mapbox-style.js
@@ -13,7 +13,20 @@ module.exports = async (layerGroups) => {
   let sourceIds = [];
 
   layerGroups.forEach((layerGroupConfig) => {
-    const internalLayers = layerGroupConfig.layers.map(d => d.layer);
+    const { id, visible: layerGroupVisible } = layerGroupConfig;
+    const internalLayers = layerGroupConfig.layers.map((d) => {
+      const { layer } = d;
+
+      // set metadata to tie layer to layergroup
+      layer.metadata = {
+        'nycplanninglabs:layergroupid': id,
+      };
+
+      // set initial visibility to match visible property of layergroup
+      layer.visibility = layerGroupVisible ? 'visible' : 'none';
+
+      return layer;
+    });
     const internalSourceIds = internalLayers.map(d => d.source);
     layers = [...layers, ...internalLayers];
     sourceIds = [...sourceIds, ...internalSourceIds];


### PR DESCRIPTION
- Sets the `visibility` property on each `layer` to match the `visible` property on its layergroup.  This allows a client to request a layergroup with `visibile:false` and expect that each of that layergroup's corresponding layers will be initially set to `visibility:none`, so they will be hidden and will not request any data/tiles.

- Sets `metadata.planninglabs:layergroupid` to the id of the layergroup.  This will be useful in the frontend to manipulate all layers associated with a layergroup.

- Adds tests for both ^^