### PR TITLE
Json api serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "array-unique": "^0.3.2",
     "deepmerge": "2.1.1",
     "joi": "13.5.2",
+    "jsonapi-serializer": "3.5.6",
     "koa": "^2.5.2",
     "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",

--- a/routes/v1/layer-groups.js
+++ b/routes/v1/layer-groups.js
@@ -1,6 +1,7 @@
 const Router = require('koa-router');
 const Joi = require('joi');
 const layerGroupSerializer = require('../../serializers/layer-groups');
+const layerGroupSchema = require('../../schemas/layer-group');
 const merge = require('../../utils/deep-merge-with-array-replace');
 const buildMapboxStyle = require('../../utils/build-mapbox-style');
 const { where, findAll } = require('../../utils/local-resources-utilities');
@@ -10,14 +11,7 @@ const router = new Router();
 const querySchema = Joi.object().keys({
   'layer-groups': Joi.array().items(
     Joi.string(),
-    Joi.object().keys({
-      id: Joi.string().required(),
-      title: Joi.string(),
-      visible: Joi.boolean(),
-      titleTooltip: Joi.string(),
-      meta: Joi.object(),
-      layers: Joi.array().items(Joi.object()),
-    }),
+    layerGroupSchema,
   ),
 });
 
@@ -57,11 +51,13 @@ router.post('/', async (ctx) => {
     data = merge(originalObjects, query);
   }
 
-  const meta = {
+  const responseBody = layerGroupSerializer(data);
+
+  responseBody.meta = {
     mapboxStyle: await buildMapboxStyle(data),
   };
 
-  ctx.body = { data, meta };
+  ctx.body = responseBody;
 });
 
 module.exports = router;

--- a/routes/v1/layer-groups.js
+++ b/routes/v1/layer-groups.js
@@ -19,19 +19,19 @@ router.get('/', async (ctx) => {
   const { 'ids[]': ids } = ctx.request.query;
 
   let data;
+
   if (ids) {
     data = await where('layer-groups', { id: ids });
   } else {
     data = await findAll('layer-groups');
   }
 
-  const responseBody = layerGroupSerializer(data);
-
-  responseBody.meta = {
-    mapboxStyle: await buildMapboxStyle(data),
+  ctx.body = {
+    ...layerGroupSerializer(data),
+    meta: {
+      mapboxStyle: await buildMapboxStyle(data),
+    },
   };
-
-  ctx.body = responseBody;
 });
 
 router.post('/', async (ctx) => {
@@ -51,13 +51,12 @@ router.post('/', async (ctx) => {
     data = merge(originalObjects, query);
   }
 
-  const responseBody = layerGroupSerializer(data);
-
-  responseBody.meta = {
-    mapboxStyle: await buildMapboxStyle(data),
+  ctx.body = {
+    ...layerGroupSerializer(data),
+    meta: {
+      mapboxStyle: await buildMapboxStyle(data),
+    },
   };
-
-  ctx.body = responseBody;
 });
 
 module.exports = router;

--- a/schemas/layer-group.js
+++ b/schemas/layer-group.js
@@ -1,0 +1,24 @@
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  id: Joi.string().required(),
+  title: Joi.string(),
+  visible: Joi.boolean(),
+  layerVisibilityType: Joi.string(),
+  titleTooltip: Joi.string(),
+  meta: Joi.object(),
+  layers: Joi.array().items(
+    Joi.object({
+      style: Joi.object().required(),
+      displayName: Joi.string(),
+      before: Joi.string(),
+      clickable: Joi.boolean(),
+      highlightable: Joi.boolean(),
+      tooltipable: Joi.boolean(),
+      tooltipTemplate: Joi.string(),
+    }),
+  ),
+  legendConfig: Joi.object(),
+  legendIcon: Joi.string(),
+  legendColor: Joi.string(),
+});

--- a/schemas/layer-group.js
+++ b/schemas/layer-group.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const layerSchema = require('./layer');
 
 module.exports = Joi.object().keys({
   id: Joi.string().required(),
@@ -8,15 +9,7 @@ module.exports = Joi.object().keys({
   titleTooltip: Joi.string(),
   meta: Joi.object(),
   layers: Joi.array().items(
-    Joi.object({
-      style: Joi.object().required(),
-      displayName: Joi.string(),
-      before: Joi.string(),
-      clickable: Joi.boolean(),
-      highlightable: Joi.boolean(),
-      tooltipable: Joi.boolean(),
-      tooltipTemplate: Joi.string(),
-    }),
+    layerSchema,
   ),
   legendConfig: Joi.object(),
   legendIcon: Joi.string(),

--- a/schemas/layer.js
+++ b/schemas/layer.js
@@ -1,0 +1,11 @@
+const Joi = require('joi');
+
+module.exports = Joi.object({
+  style: Joi.object().required(),
+  displayName: Joi.string(),
+  before: Joi.string(),
+  clickable: Joi.boolean(),
+  highlightable: Joi.boolean(),
+  tooltipable: Joi.boolean(),
+  tooltipTemplate: Joi.string(),
+});

--- a/schemas/source.js
+++ b/schemas/source.js
@@ -1,0 +1,26 @@
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  id: Joi.string().required(),
+  type: Joi.valid(
+    'vector',
+    'raster',
+    'geojson',
+    'cartovector',
+  ),
+  minzoom: Joi.number(),
+  maxzoom: Joi.number(),
+  'source-layers': Joi.array().items(Joi.object())
+    .when('type', {
+      is: 'cartovector',
+      then: Joi.required(),
+    }),
+  tiles: Joi.array().items(Joi.string()).when('type', {
+    is: 'raster',
+    then: Joi.required(),
+  }),
+  tileSize: Joi.number().when('type', {
+    is: 'raster',
+    then: Joi.required(),
+  }),
+});

--- a/serializers/layer-groups.js
+++ b/serializers/layer-groups.js
@@ -1,0 +1,12 @@
+const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+
+module.exports = data => new JSONAPISerializer('layer-groups', {
+  attributes: ['title', 'visible', 'layerVisibilityType', 'titleTooltip', 'meta', 'layers', 'legendConfig', 'legendIcon', 'legendColor'],
+  layers: {
+    ref(parent, child) {
+      return child.style.id;
+    },
+    included: true,
+    attributes: ['style', 'displayName', 'before', 'clickable', 'highlightable', 'tooltipable', 'tooltipTemplate'],
+  },
+}).serialize(data);

--- a/serializers/layer-groups.js
+++ b/serializers/layer-groups.js
@@ -1,12 +1,17 @@
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const layerGroupSchema = require('../schemas/layer-group');
+const layerSchema = require('../schemas/layer');
+
+const { children: layerGroupAttrs } = layerGroupSchema.describe();
+const { children: layerAttrs } = layerSchema.describe();
 
 module.exports = data => new JSONAPISerializer('layer-groups', {
-  attributes: ['title', 'visible', 'layerVisibilityType', 'titleTooltip', 'meta', 'layers', 'legendConfig', 'legendIcon', 'legendColor'],
+  attributes: Object.keys(layerGroupAttrs),
   layers: {
     ref(parent, child) {
       return child.style.id;
     },
     included: true,
-    attributes: ['style', 'displayName', 'before', 'clickable', 'highlightable', 'tooltipable', 'tooltipTemplate'],
+    attributes: Object.keys(layerAttrs),
   },
 }).serialize(data);

--- a/test/acceptance/routes.layer-group.test.js
+++ b/test/acceptance/routes.layer-group.test.js
@@ -101,8 +101,8 @@ describe('POST /layer-groups', () => {
           console.log(errors[0]); // eslint-disable-line
         }
 
-        const { title: taxLotsTitle } = data.find(d => d.id === 'tax-lots');
-        const { title: zdTitle } = data.find(d => d.id === 'zoning-districts');
+        const { attributes: { title: taxLotsTitle } } = data.find(d => d.id === 'tax-lots');
+        const { attributes: { title: zdTitle } } = data.find(d => d.id === 'zoning-districts');
 
         taxLotsTitle.should.equal('bananas');
         zdTitle.should.equal('peanut butter');
@@ -149,7 +149,7 @@ describe('POST /layer-groups', () => {
         ],
       })
       .end((err, res) => {
-        const { data, errors } = res.body;
+        const { included, errors } = res.body;
 
         expect(errors).to.equal(undefined);
 
@@ -158,7 +158,7 @@ describe('POST /layer-groups', () => {
         }
 
         const {
-          layers: [{
+          attributes: {
             style: {
               minzoom,
               source,
@@ -172,8 +172,8 @@ describe('POST /layer-groups', () => {
                 },
               },
             },
-          }],
-        } = data.find(d => d.id === 'tax-lots');
+          },
+        } = included.find(d => d.id === 'pluto-fill');
 
         minzoom.should.equal(15);
         source.should.equal('pluto');
@@ -228,7 +228,7 @@ describe('POST /layer-groups', () => {
         ],
       })
       .end((err, res) => {
-        const { data, errors } = res.body;
+        const { included, errors } = res.body;
 
         expect(errors).to.equal(undefined);
 
@@ -237,7 +237,7 @@ describe('POST /layer-groups', () => {
         }
 
         const {
-          layers: [{
+          attributes: {
             style: {
               minzoom,
               source,
@@ -250,8 +250,8 @@ describe('POST /layer-groups', () => {
                 },
               },
             },
-          }],
-        } = data.find(d => d.id === 'tax-lots');
+          },
+        } = included.find(d => d.id === 'pluto-fill');
 
         minzoom.should.equal(14);
         source.should.equal('pluto');
@@ -285,7 +285,7 @@ describe('POST /layer-groups', () => {
         ],
       })
       .end((err, res) => {
-        const { data, errors } = res.body;
+        const { included, errors } = res.body;
 
         expect(errors).to.equal(undefined);
 
@@ -294,20 +294,24 @@ describe('POST /layer-groups', () => {
         }
 
         const {
-          layers: [{
+          attributes: {
             style: {
               id,
               minzoom,
               source,
             },
-          }, {
+          },
+        } = included.find(d => d.id === 'pluto-fill');
+
+        const {
+          attributes: {
             style: {
               id: secondId,
               minzoom: secondMinZoom,
               source: secondSource,
             },
-          }],
-        } = data.find(d => d.id === 'tax-lots');
+          },
+        } = included.find(d => d.id === 'pluto-line');
 
         id.should.equal('pluto-fill');
         minzoom.should.equal(15);
@@ -359,7 +363,7 @@ describe('POST /layer-groups', () => {
         ],
       })
       .end((err, res) => {
-        const { data, errors } = res.body;
+        const { included, errors } = res.body;
 
         expect(errors).to.equal(undefined);
 
@@ -368,7 +372,7 @@ describe('POST /layer-groups', () => {
         }
 
         const {
-          layers: [{
+          attributes: {
             style: {
               minzoom,
               source,
@@ -382,8 +386,8 @@ describe('POST /layer-groups', () => {
                 },
               },
             },
-          }],
-        } = data.find(d => d.id === 'tax-lots');
+          },
+        } = included.find(d => d.id === 'pluto-fill');
 
         minzoom.should.equal(15);
         source.should.equal('pluto');

--- a/test/validations/data.js
+++ b/test/validations/data.js
@@ -1,62 +1,14 @@
 const chai = require('chai');
-const Joi = require('joi');
 const path = require('path');
 const fs = require('fs');
 
+const layerGroupSchema = require('../../schemas/layer-group');
+const sourceSchema = require('../../schemas/source');
 const { find } = require('../../utils/local-resources-utilities');
-
 
 const getFilenames = resourceName => fs.readdirSync(path.resolve(__dirname, `../../data/${resourceName}`));
 
 const should = chai.should();
-
-const layerGroupSchema = Joi.object().keys({
-  id: Joi.string().required(),
-  title: Joi.string(),
-  visible: Joi.boolean(),
-  layerVisibilityType: Joi.string(),
-  titleTooltip: Joi.string(),
-  meta: Joi.object(),
-  layers: Joi.array().items(
-    Joi.object({
-      style: Joi.object().required(),
-      displayName: Joi.string(),
-      before: Joi.string(),
-      clickable: Joi.boolean(),
-      highlightable: Joi.boolean(),
-      tooltipable: Joi.boolean(),
-      tooltipTemplate: Joi.string(),
-    }),
-  ),
-  legendConfig: Joi.object(),
-  legendIcon: Joi.string(),
-  legendColor: Joi.string(),
-});
-
-const sourceSchema = Joi.object().keys({
-  id: Joi.string().required(),
-  type: Joi.valid(
-    'vector',
-    'raster',
-    'geojson',
-    'cartovector',
-  ),
-  minzoom: Joi.number(),
-  maxzoom: Joi.number(),
-  'source-layers': Joi.array().items(Joi.object())
-    .when('type', {
-      is: 'cartovector',
-      then: Joi.required(),
-    }),
-  tiles: Joi.array().items(Joi.string()).when('type', {
-    is: 'raster',
-    then: Joi.required(),
-  }),
-  tileSize: Joi.number().when('type', {
-    is: 'raster',
-    then: Joi.required(),
-  }),
-});
 
 function testLayerGroup(filename) {
   it(`validates layer-groups/${filename}`, async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,6 +772,10 @@ inflation@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/inflation/-/inflation-2.0.0.tgz#8b417e47c28f925a45133d914ca1fd389107f30f"
 
+inflected@^1.1.6:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/inflected/-/inflected-1.1.7.tgz#c393df6e28472d0d77b3082ec3aa2091f4bc96f9"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -925,6 +929,13 @@ json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+jsonapi-serializer@3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/jsonapi-serializer/-/jsonapi-serializer-3.5.6.tgz#4b239ee023dd2096f1be474d2d8243747240d8a3"
+  dependencies:
+    inflected "^1.1.6"
+    lodash "^4.16.3"
+
 keygrip@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.2.tgz#ad3297c557069dea8bcfe7a4fa491b75c5ddeb91"
@@ -1029,7 +1040,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.13.1, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.16.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
This pull request:
 - Implements a serializer for layer-groups with help from new dependency. Serializes to JSON:API compliance
 - Adds folders for new objects: `serializers` and `schemas`
 - Serializers use schema to grab attributes. Validation data tests use schemas folder to validate.
 - Schemas are now composed: layerGroup schema now references a separate Layer schema.
 - Tests for the GET and POST methods on `layer-groups` are updated/add/work with changes