### PR TITLE
add third { to tooltip templates

### DIFF
--- a/data/layer-groups/citymap.json
+++ b/data/layer-groups/citymap.json
@@ -55,7 +55,7 @@
     },
     {
       "tooltipable":true,
-      "tooltipTemplate":"{{type}}",
+      "tooltipTemplate":"{{{type}}}",
       "style":{
         "id":"citymap-streets-tooltip-line",
         "type":"line",
@@ -270,7 +270,7 @@
     },
     {
       "tooltipable":true,
-      "tooltipTemplate":"{{boro_nm}}",
+      "tooltipTemplate":"{{{boro_nm}}}",
       "style":{
         "id":"borough-boundaries",
         "type":"line",
@@ -371,7 +371,7 @@
     },
     {
       "tooltipable":true,
-      "tooltipTemplate":"{{street}}",
+      "tooltipTemplate":"{{{street}}}",
       "style":{
         "id":"railway-lines",
         "type":"line",
@@ -410,8 +410,6 @@
       }
     },
     {
-      "tooltipable":true,
-      "tooltipTemplate":"{{street}}",
       "style":{
         "id":"railway-cross-lines",
         "type":"line",

--- a/data/layer-groups/commercial-overlays.json
+++ b/data/layer-groups/commercial-overlays.json
@@ -27,7 +27,7 @@
       },
       "highlightable": true,
       "clickable": true,
-      "tooltipTemplate": "{{overlay}}"
+      "tooltipTemplate": "{{{overlay}}}"
     },
     {
       "style": {

--- a/data/layer-groups/e-designations.json
+++ b/data/layer-groups/e-designations.json
@@ -52,7 +52,7 @@
             },
             "highlightable":true,
             "clickable":true,
-            "tooltipTemplate":"E-designation<br/>E-Number: {{enumber}}<br/>CEQR: {{ceqr_num}}<br/>ULURP: {{ulurp_num}}"
+            "tooltipTemplate":"E-designation<br/>E-Number: {{{enumber}}}<br/>CEQR: {{{ceqr_num}}}<br/>ULURP: {{{ulurp_num}}}"
          },
          {
             "style":{

--- a/data/layer-groups/effective-flood-insurance-rate-2007.json
+++ b/data/layer-groups/effective-flood-insurance-rate-2007.json
@@ -36,7 +36,7 @@
                }
             },
             "highlightable":true,
-            "tooltipTemplate":"2007 {{fld_zone}} Zone"
+            "tooltipTemplate":"2007 {{{fld_zone}}} Zone"
          }
       ]
    }

--- a/data/layer-groups/floodplain-efirm2007.json
+++ b/data/layer-groups/floodplain-efirm2007.json
@@ -37,7 +37,7 @@
         }
       },
       "highlightable": true,
-      "tooltipTemplate": "2007 {{fld_zone}} Zone"
+      "tooltipTemplate": "2007 {{{fld_zone}}} Zone"
     }
   ]
 }

--- a/data/layer-groups/floodplain-pfirm2015.json
+++ b/data/layer-groups/floodplain-pfirm2015.json
@@ -37,7 +37,7 @@
         }
       },
       "highlightable": true,
-      "tooltipTemplate": "2015 {{fld_zone}} Zone"
+      "tooltipTemplate": "2015 {{{fld_zone}}} Zone"
     }
   ]
 }

--- a/data/layer-groups/limited-height-districts.json
+++ b/data/layer-groups/limited-height-districts.json
@@ -56,7 +56,7 @@
                }
             },
             "highlightable":true,
-            "tooltipTemplate":"Limited height district - {{lhlbl}}"
+            "tooltipTemplate":"Limited height district - {{{lhlbl}}}"
          }
       ]
    }

--- a/data/layer-groups/mandatory-inclusionary-housing.json
+++ b/data/layer-groups/mandatory-inclusionary-housing.json
@@ -56,7 +56,7 @@
                }
             },
             "highlightable":true,
-            "tooltipTemplate":"{{projectnam}} - {{mih_option}}"
+            "tooltipTemplate":"{{{projectnam}}} - {{{mih_option}}}"
          }
       ]
    }

--- a/data/layer-groups/preliminary-flood-insurance-rate-2015.json
+++ b/data/layer-groups/preliminary-flood-insurance-rate-2015.json
@@ -36,7 +36,7 @@
                }
             },
             "highlightable":true,
-            "tooltipTemplate":"2015 {{fld_zone}} Zone"
+            "tooltipTemplate":"2015 {{{fld_zone}}} Zone"
          }
       ]
    }

--- a/data/layer-groups/special-purpose-subdistricts.json
+++ b/data/layer-groups/special-purpose-subdistricts.json
@@ -57,7 +57,7 @@
             },
             "highlightable":true,
             "clickable":true,
-            "tooltipTemplate":"{{spname}} - {{subdist}}"
+            "tooltipTemplate":"{{{spname}}} - {{{subdist}}}"
          }
       ]
    }

--- a/data/layer-groups/tax-lots.json
+++ b/data/layer-groups/tax-lots.json
@@ -5,7 +5,7 @@
   "meta":
   {
     "description": "MapPLUTO™ v18.1, Bytes of the Big Apple",
-    "url": 
+    "url":
     [
       "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
     ],
@@ -93,7 +93,7 @@
       },
       "highlightable": true,
       "clickable": true,
-      "tooltipTemplate": "{{address}}"
+      "tooltipTemplate": "{{{address}}}"
     },
     {
       "style":

--- a/data/layer-groups/zoning-districts.json
+++ b/data/layer-groups/zoning-districts.json
@@ -167,7 +167,7 @@
       },
       "highlightable": true,
       "clickable": true,
-      "tooltipTemplate": "Zoning District {{zonedist}}"
+      "tooltipTemplate": "Zoning District {{{zonedist}}}"
     },
     {
       "style":


### PR DESCRIPTION
Add {{{ }}} too tooltip templates to avoid HTML escape formatting for map tooltips