### PR TITLE
add fields needed for public park popup

### DIFF
--- a/data/sources/paws.json
+++ b/data/sources/paws.json
@@ -8,7 +8,7 @@
     },
     {
       "id": "publiclyownedwaterfront",
-      "sql": "SELECT the_geom_webmercator, cartodb_id, park_name, link FROM publiclyownedwaterfront_v201810"
+      "sql": "SELECT the_geom_webmercator, cartodb_id, wf_park_id, park_name, link, agency, status FROM publiclyownedwaterfront_v201810"
     },
     {
       "id": "paws_footprints",


### PR DESCRIPTION
This PR expands the fields collected from the publiclyownedwaterfront table, so they can be used in a pop up in the waterfront access map.