### PR TITLE
New Administrative Boundaries Colors 

### DIFF
--- a/data/layer-groups/assembly-districts.json
+++ b/data/layer-groups/assembly-districts.json
@@ -6,7 +6,7 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#8A76F5",
+          "stroke": "#12ed12",
           "stroke-width": 4,
           "stroke-opacity": 0.5
         },
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "ny-assembly-districts",
         "paint": {
-          "line-color": "#8A76F5",
-          "line-opacity": 0.2,
+          "line-color": "#12ed12",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/boroughs.json
+++ b/data/layer-groups/boroughs.json
@@ -6,9 +6,9 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#F5B176",
+          "stroke": "#2929ed",
           "stroke-width": 4,
-          "stroke-opacity": 0.5
+          "stroke-opacity": 0.6
         },
         {
           "stroke": "#444",
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "boroughs",
         "paint": {
-          "line-color": "#F5B176",
-          "line-opacity": 0.2,
+          "line-color": "#2929ed",
+          "line-opacity": 0.6,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/community-districts.json
+++ b/data/layer-groups/community-districts.json
@@ -1,13 +1,12 @@
 {
   "id": "community-districts",
-  "visible": false,
   "legend": {
     "label": "Community Districts",
     "icon": {
       "type": "line",
       "layers": [
         {
-          "stroke": "#76F578",
+          "stroke": "#12eded",
           "stroke-width": 4,
           "stroke-opacity": 0.5
         },
@@ -27,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "community-districts",
         "paint": {
-          "line-color": "#76F578",
-          "line-opacity": 0.2,
+          "line-color": "#12eded",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/neighborhood-tabulation-areas.json
+++ b/data/layer-groups/neighborhood-tabulation-areas.json
@@ -6,9 +6,9 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#F576CC",
+          "stroke": "#eded12",
           "stroke-width": 4,
-          "stroke-opacity": 0.5
+          "stroke-opacity": 0.75
         },
         {
           "stroke": "#444",
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "neighborhood-tabulation-areas",
         "paint": {
-          "line-color": "#F576CC",
-          "line-opacity": 1,
+          "line-color": "#eded12",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/ny-senate-districts.json
+++ b/data/layer-groups/ny-senate-districts.json
@@ -6,7 +6,7 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#E4F576",
+          "stroke": "#a5ed12",
           "stroke-width": 4,
           "stroke-opacity": 0.5
         },
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "ny-senate-districts",
         "paint": {
-          "line-color": "#E4F576",
-          "line-opacity": 1,
+          "line-color": "#a5ed12",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/nyc-council-districts.json
+++ b/data/layer-groups/nyc-council-districts.json
@@ -6,7 +6,7 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#76CAF5",
+          "stroke": "#129ded",
           "stroke-width": 4,
           "stroke-opacity": 0.5
         },
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "nyc-council-districts",
         "paint": {
-          "line-color": "#76CAF5",
-          "line-opacity": 1,
+          "line-color": "#129ded",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [

--- a/data/layer-groups/nyc-pumas.json
+++ b/data/layer-groups/nyc-pumas.json
@@ -6,9 +6,9 @@
       "type": "line",
       "layers": [
         {
-          "stroke": "#F5B176",
+          "stroke": "#9664b4",
           "stroke-width": 4,
-          "stroke-opacity": 0.5
+          "stroke-opacity": 0.75
         },
         {
           "stroke": "#444",
@@ -26,8 +26,8 @@
         "source": "admin-boundaries",
         "source-layer": "nyc-pumas",
         "paint": {
-          "line-color": "#F5B176",
-          "line-opacity": 1,
+          "line-color": "#9664b4",
+          "line-opacity": 0.75,
           "line-width": {
             "stops": [
               [


### PR DESCRIPTION
This PR changes all the administrative boundary colors to work better with Population FactFinder. Since PFF and other apps (e.g. ZoLa) use these layer groups, all 7 files were to be adjusted not just the one referenced in the PFF issue. Closes https://github.com/NYCPlanning/labs-factfinder/issues/663. 
