### PR TITLE
736: Add external link to e-designation tooltip label

### DIFF
--- a/data/layer-groups/e-designations.json
+++ b/data/layer-groups/e-designations.json
@@ -60,7 +60,7 @@
       "highlightable": true,
       "clickable": true,
       "tooltipable": true,
-      "tooltipTemplate": "E-designation, E-Number: {{{enumber}}}, CEQR: {{{ceqr_num}}}, ULURP: {{{ulurp_num}}}"
+      "tooltipTemplate": "{{fa-icon 'external-link-alt'}} E-designation, E-Number: {{{enumber}}}, CEQR: {{{ceqr_num}}}, ULURP: {{{ulurp_num}}}"
     },
     {
       "style": {


### PR DESCRIPTION
This PR adds external link icon to template for e-designation tooltip label
Addresses issue #736, but does not close it because dot still needs to be made highlightable on hover 