### PR TITLE
737: add links to legends for supporting zoning layers

### DIFF
--- a/data/layer-groups/appendixj-designated-mdistricts.json
+++ b/data/layer-groups/appendixj-designated-mdistricts.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Appendix J Designated M Districts",
     "tooltip": "Designated areas within Manufacturing Districts in which self service storage facilities are subject to certain as-of-right provisions (subarea 1) or are subject to special permit by the City Planning Commission (subarea 2)",
-    "link": "https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/designated_areas_m_districts_metadata.pdf",
+    "infolink": "https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/designated_areas_m_districts_metadata.pdf",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/appendixj-designated-mdistricts.json
+++ b/data/layer-groups/appendixj-designated-mdistricts.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Appendix J Designated M Districts",
     "tooltip": "Designated areas within Manufacturing Districts in which self service storage facilities are subject to certain as-of-right provisions (subarea 1) or are subject to special permit by the City Planning Commission (subarea 2)",
+    "link": "https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/designated_areas_m_districts_metadata.pdf",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/coastal-zone-boundary.json
+++ b/data/layer-groups/coastal-zone-boundary.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Coastal Zone Boundary",
     "tooltip": "Projects within the coastal zone boundary are subject to additional review under the Waterfront Revitalization Program",
+    "link": "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/coastal-zone-boundary.json
+++ b/data/layer-groups/coastal-zone-boundary.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Coastal Zone Boundary",
     "tooltip": "Projects within the coastal zone boundary are subject to additional review under the Waterfront Revitalization Program",
-    "link": "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page",
+    "infolink": "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/e-designations.json
+++ b/data/layer-groups/e-designations.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Environmental Designations",
     "tooltip": "An E-Designation is a NYC zoning map designation that indicates the presence of an environmental requirement pertaining to potential Hazardous Materials Contamination, Window/Wall Noise Attenuation, or Air Quality impacts on a particular tax lot.",
+    "link": "https://www1.nyc.gov/site/planning/applicants/e-faq.page",
     "icon": {
       "type": "fa-icon",
       "layers": [

--- a/data/layer-groups/e-designations.json
+++ b/data/layer-groups/e-designations.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Environmental Designations",
     "tooltip": "An E-Designation is a NYC zoning map designation that indicates the presence of an environmental requirement pertaining to potential Hazardous Materials Contamination, Window/Wall Noise Attenuation, or Air Quality impacts on a particular tax lot.",
-    "link": "https://www1.nyc.gov/site/planning/applicants/e-faq.page",
+    "infolink": "https://www1.nyc.gov/site/planning/applicants/e-faq.page",
     "icon": {
       "type": "fa-icon",
       "layers": [

--- a/data/layer-groups/effective-flood-insurance-rate-2007.json
+++ b/data/layer-groups/effective-flood-insurance-rate-2007.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Effective Flood Insurance Rate Maps 2007",
     "tooltip": "The Effective Flood Insurance Rate Maps (FIRMs), first adopted by New York City in 1983 and last updated in 2007, establish the floodplain currently subject to the National Flood Insurance Program purchase requirements.",
+    "link": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
     "items": [
       {
         "label": "V Zone",

--- a/data/layer-groups/effective-flood-insurance-rate-2007.json
+++ b/data/layer-groups/effective-flood-insurance-rate-2007.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Effective Flood Insurance Rate Maps 2007",
     "tooltip": "The Effective Flood Insurance Rate Maps (FIRMs), first adopted by New York City in 1983 and last updated in 2007, establish the floodplain currently subject to the National Flood Insurance Program purchase requirements.",
-    "link": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
+    "infolink": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
     "items": [
       {
         "label": "V Zone",

--- a/data/layer-groups/fresh.json
+++ b/data/layer-groups/fresh.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "FRESH Zones",
     "tooltip": "FRESH promotes the establishment and expansion of neighborhood grocery stores in underserved communities by providing zoning and financial incentives",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/fresh-food-stores.page",
     "items": [
       {
         "label": "Zoning incentives",

--- a/data/layer-groups/fresh.json
+++ b/data/layer-groups/fresh.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "FRESH Zones",
     "tooltip": "FRESH promotes the establishment and expansion of neighborhood grocery stores in underserved communities by providing zoning and financial incentives",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/fresh-food-stores.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/fresh-food-stores.page",
     "items": [
       {
         "label": "Zoning incentives",

--- a/data/layer-groups/inclusionary-housing.json
+++ b/data/layer-groups/inclusionary-housing.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Inclusionary Housing Designated Areas",
     "tooltip": "Areas where zoning incentives are offered to encourage the creation of permanently affordable housing",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/inclusionary-housing.json
+++ b/data/layer-groups/inclusionary-housing.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Inclusionary Housing Designated Areas",
     "tooltip": "Areas where zoning incentives are offered to encourage the creation of permanently affordable housing",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/low-density-growth-mgmt-areas.json
+++ b/data/layer-groups/low-density-growth-mgmt-areas.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Lower Density Growth Management Areas",
     "tooltip": "Areas where special zoning controls intend to limit growth and better match available infrastructure and services in lower-density areas experiencing rapid development",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/lower-density-growth-mngmt.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/lower-density-growth-mngmt.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/low-density-growth-mgmt-areas.json
+++ b/data/layer-groups/low-density-growth-mgmt-areas.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Lower Density Growth Management Areas",
     "tooltip": "Areas where special zoning controls intend to limit growth and better match available infrastructure and services in lower-density areas experiencing rapid development",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/lower-density-growth-mngmt.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/mandatory-inclusionary-housing.json
+++ b/data/layer-groups/mandatory-inclusionary-housing.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Mandatory Inclusionary Housing Areas",
     "tooltip": "Areas where developments, enlargements and conversions over a certain size are required to set aside a percentage of floor area for permanently affordable housing",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/mandatory-inclusionary-housing.json
+++ b/data/layer-groups/mandatory-inclusionary-housing.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Mandatory Inclusionary Housing Areas",
     "tooltip": "Areas where developments, enlargements and conversions over a certain size are required to set aside a percentage of floor area for permanently affordable housing",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/preliminary-flood-insurance-rate-2015.json
+++ b/data/layer-groups/preliminary-flood-insurance-rate-2015.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Preliminary Flood Insurance Rate Maps 2015",
     "tooltip": "Released in 2015 as part of a citywide flood map update, the Preliminary FIRMs establish the 1% annual chance floodplain. For building code and zoning purposes, the more expansive of the either the 2015 or 2007 maps is used.",
+    "link": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
     "items": [
       {
         "label": "V Zone",

--- a/data/layer-groups/preliminary-flood-insurance-rate-2015.json
+++ b/data/layer-groups/preliminary-flood-insurance-rate-2015.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Preliminary Flood Insurance Rate Maps 2015",
     "tooltip": "Released in 2015 as part of a citywide flood map update, the Preliminary FIRMs establish the 1% annual chance floodplain. For building code and zoning purposes, the more expansive of the either the 2015 or 2007 maps is used.",
-    "link": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
+    "infolink": "https://www1.nyc.gov/site/planning/plans/climate-resiliency-faq.page",
     "items": [
       {
         "label": "V Zone",

--- a/data/layer-groups/sidewalk-cafes.json
+++ b/data/layer-groups/sidewalk-cafes.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Sidewalk Cafes",
     "tooltip": "Areas where different types of sidewalk cafes are permitted on public sidewalks",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/sidewalk-cafes.page",
     "items": [
       {
         "label": "All Cafes Permitted",

--- a/data/layer-groups/sidewalk-cafes.json
+++ b/data/layer-groups/sidewalk-cafes.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Sidewalk Cafes",
     "tooltip": "Areas where different types of sidewalk cafes are permitted on public sidewalks",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/sidewalk-cafes.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/sidewalk-cafes.page",
     "items": [
       {
         "label": "All Cafes Permitted",

--- a/data/layer-groups/transit-zones.json
+++ b/data/layer-groups/transit-zones.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Transit Zones",
     "tooltip": "Transit-accessible areas where parking is optional for new affordable housing units and special rules apply to existing affordable units",
-    "link": "https://www1.nyc.gov/site/planning/zoning/glossary.page#transit_zone",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/glossary.page#transit_zone",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/transit-zones.json
+++ b/data/layer-groups/transit-zones.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Transit Zones",
     "tooltip": "Transit-accessible areas where parking is optional for new affordable housing units and special rules apply to existing affordable units",
+    "link": "https://www1.nyc.gov/site/planning/zoning/glossary.page#transit_zone",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/waterfront-access-plan.json
+++ b/data/layer-groups/waterfront-access-plan.json
@@ -3,6 +3,7 @@
   "legend": {
     "label": "Waterfront Access Plan",
     "tooltip": "These areas reflect site specific modification of waterfront public access requirements for waterfront parcels with unique conditions and opportunities",
+    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/waterfront-zoning.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/data/layer-groups/waterfront-access-plan.json
+++ b/data/layer-groups/waterfront-access-plan.json
@@ -3,7 +3,7 @@
   "legend": {
     "label": "Waterfront Access Plan",
     "tooltip": "These areas reflect site specific modification of waterfront public access requirements for waterfront parcels with unique conditions and opportunities",
-    "link": "https://www1.nyc.gov/site/planning/zoning/districts-tools/waterfront-zoning.page",
+    "infolink": "https://www1.nyc.gov/site/planning/zoning/districts-tools/waterfront-zoning.page",
     "icon": {
       "type": "rectangle",
       "layers": [

--- a/schemas/layer-group.js
+++ b/schemas/layer-group.js
@@ -31,6 +31,7 @@ module.exports = Joi.object().keys({
   legend: Joi.object().keys({
     label: Joi.string().required(),
     tooltip: Joi.string(),
+    infolink: Joi.string(),
     icon: legendIconSchema,
     items: Joi.array().items(
       legendItemSchema,


### PR DESCRIPTION
This PR adds a `link` property as a child to the `legend` object in 12 layer-groups. These are all "supporting" layers that do not have their own profiles in zola.

Overall goal is to add "link" icons next to tooltip icons in the layer-group legend. These icons link out to an information page for the associated supporting layers. A `legend-link-icon` component will also be added to `labs-ui` so that the zola front end only requires `layerGroups.layer-name.legend.link`