### PR TITLE
add optional buffersize to source configs, send to carto

### DIFF
--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -40,6 +40,9 @@
     }
   ],
   "minzoom": 0,
+  "buffersize": {
+    "mvt": 10
+  },
   "meta": {
     "description": "Administrative and Political Districts v18D, Bytes of the Big Apple",
     "url": [

--- a/schemas/source.js
+++ b/schemas/source.js
@@ -23,5 +23,8 @@ module.exports = Joi.object().keys({
     is: 'raster',
     then: Joi.required(),
   }),
+  buffersize: Joi.object().keys({
+    mvt: Joi.number(),
+  }),
   meta: Joi.object(),
 });

--- a/utils/carto.js
+++ b/utils/carto.js
@@ -35,9 +35,9 @@ const carto = {
       });
   },
 
-  getVectorTileTemplate(sourceLayers) {
+  getVectorTileTemplate(sourceConfig) {
     const CartoCSS = '#layer { polygon-fill: #FFF; }';
-    const layers = sourceLayers.map((sourceLayer) => {
+    const layers = sourceConfig['source-layers'].map((sourceLayer) => {
       const { id, sql } = sourceLayer;
       return {
         id,
@@ -54,6 +54,9 @@ const carto = {
       version: '1.3.0',
       layers,
     };
+
+    // if buffersize is defined in the source json, add it to the carto params
+    if (sourceConfig.buffersize) params.buffersize = sourceConfig.buffersize;
 
     return new Promise((resolve, reject) => {
       fetch(`https://${cartoDomain}/api/v1/map`, {

--- a/utils/structure-carto-source.js
+++ b/utils/structure-carto-source.js
@@ -5,7 +5,7 @@ module.exports = async (sourceConfig) => {
 
   if (type === 'cartovector') {
     // instantiate carto vector tiles, get back the tile template
-    const template = await carto.getVectorTileTemplate(sourceConfig['source-layers']);
+    const template = await carto.getVectorTileTemplate(sourceConfig);
 
     // make an object with sourceid as a key, and valid mapboxGL source as value
     const source = {};


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds an optional `buffersize` property to source configs.  This is used when instantiating vector tiles in carto.  The default value of `buffersize.mvt` is `0` in carto's maps api.  This was causing the tile boundary to appear in mapboxgl for large polygons that span a tile boundary visualized as type `line` with a large line-width.

Once deployed, closes this issue in ZoLa: https://github.com/NYCPlanning/labs-zola/issues/774
