### PR TITLE
App maps issue 83: add property for basemap mapboxStyle building visibility

### DIFF
--- a/data/base/style.json
+++ b/data/base/style.json
@@ -282,8 +282,11 @@
        "paint":{
           "fill-color":"rgb(234, 234, 229)",
           "fill-outline-color":"rgb(219, 219, 218)",
-          "fill-antialias":true
-       }
+          "fill-antialias": true
+        },
+        "layout": {
+          "visibility": "visible"
+        }
     },
     {
        "id":"tunnel_motorway_casing",


### PR DESCRIPTION
This PR adds the property `visibility` to the `building` layer on the mapboxStyle basemap. This allows for us to toggle the visibility from `visible` to `none` in the front end of Applicant Maps. 

This is so that I can add our own `building-footprints` layer-group, which allows for more specific styling depending on different maps. 