### PR TITLE
use-aliased-data

### DIFF
--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -4,39 +4,39 @@
   "source-layers": [
     {
       "id": "community-districts",
-      "sql": "SELECT the_geom_webmercator, borocd, CASE WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '3' THEN 'Brooklyn ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '4' THEN 'Queens ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '5' THEN 'Staten Island ' || borocd % 100 END as boro_district FROM community_districts_v201811 WHERE borocd % 100 < 20"
+      "sql": "SELECT the_geom_webmercator, borocd, CASE WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '3' THEN 'Brooklyn ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '4' THEN 'Queens ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '5' THEN 'Staten Island ' || borocd % 100 END as boro_district FROM community_districts WHERE borocd % 100 < 20"
     },
     {
       "id": "neighborhood-tabulation-areas",
-      "sql": "SELECT the_geom_webmercator, ntaname, ntaname AS id, a.ntacode AS geoid FROM nta_boundaries_v201811 a WHERE ntaname NOT ILIKE 'park-cemetery-etc%' AND ntaname != 'Airport'"
+      "sql": "SELECT the_geom_webmercator, ntaname, ntaname AS id, a.ntacode AS geoid FROM nta_boundaries a WHERE ntaname NOT ILIKE 'park-cemetery-etc%' AND ntaname != 'Airport'"
     },
     {
       "id": "neighborhood-tabulation-areas-centroids",
-      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM nta_boundaries_v201811 WHERE ntaname NOT ILIKE 'park-cemetery-etc%'"
+      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM nta_boundaries WHERE ntaname NOT ILIKE 'park-cemetery-etc%'"
     },
     {
       "id": "boroughs",
-      "sql": "SELECT the_geom_webmercator, boroname FROM boro_boundaries_V201811"
+      "sql": "SELECT the_geom_webmercator, boroname FROM boro_boundaries"
     },
     {
       "id": "nyc-council-districts",
-      "sql": "SELECT the_geom_webmercator, coundist FROM nyc_council_districts_v201811"
+      "sql": "SELECT the_geom_webmercator, coundist FROM nyc_council_districts"
     },
     {
       "id": "ny-senate-districts",
-      "sql": "SELECT the_geom_webmercator, stsendist FROM ny_senate_districts_v201811"
+      "sql": "SELECT the_geom_webmercator, stsendist FROM ny_senate_districts"
     },
     {
       "id": "ny-assembly-districts",
-      "sql": "SELECT the_geom_webmercator, assemdist FROM ny_assembly_districts_v201811"
+      "sql": "SELECT the_geom_webmercator, assemdist FROM ny_assembly_districts"
     },
     {
       "id": "nyc-pumas",
-      "sql": "SELECT the_geom_webmercator, puma, puma AS id, puma AS geoid FROM nyc_pumas_v201811"
+      "sql": "SELECT the_geom_webmercator, puma, puma AS id, puma AS geoid FROM nyc_pumas"
     },
     {
       "id": "bk-qn-mh-boundary",
-      "sql": "SELECT the_geom_webmercator, label1 || '/' || label2 AS boro_boundary FROM bk_qn_mh_boundary_v201804"
+      "sql": "SELECT the_geom_webmercator, label1 || '/' || label2 AS boro_boundary FROM bk_qn_mh_boundary"
     }
   ],
   "minzoom": 0,

--- a/data/sources/boat-launches.json
+++ b/data/sources/boat-launches.json
@@ -4,13 +4,13 @@
   "source-layers": [
     {
       "id": "boat-launches",
-      "sql": "SELECT the_geom_webmercator, cartodb_id, comments, link, name, notes FROM humanboatlaunch_v201810"
+      "sql": "SELECT the_geom_webmercator, cartodb_id, comments, link, name, notes FROM humanboatlaunch"
     }
   ],
   "meta": {
     "description": "Boat Launches",
     "url": [
-      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM humanboatlaunch_v201810&format=SHP"
+      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM humanboatlaunch&format=SHP"
     ],
     "updated_at": "October 2018"
   }

--- a/data/sources/census-geoms.json
+++ b/data/sources/census-geoms.json
@@ -4,11 +4,11 @@
   "source-layers": [
     {
       "id": "census-geoms-tracts",
-      "sql": "SELECT the_geom_webmercator, ct2010, ctlabel as geolabel, boroct2010, ntacode, boroct2010 AS geoid, boroct2010 AS id FROM nyc_census_tracts_2010"
+      "sql": "SELECT the_geom_webmercator, ct2010, ctlabel as geolabel, boroct2010, ntacode, boroct2010 AS geoid, boroct2010 AS id FROM nyc_census_tracts"
     },
     {
       "id": "census-geoms-blocks",
-      "sql": "SELECT the_geom_webmercator, ct2010, borocode || ct2010 AS boroct2010, cb2010, borocode, bctcb2010, bctcb2010 AS geoid, bctcb2010 AS id, (ct2010::float / 100)::text || ' - ' || cb2010 as geolabel FROM nyc_census_blocks_2010"
+      "sql": "SELECT the_geom_webmercator, ct2010, borocode || ct2010 AS boroct2010, cb2010, borocode, bctcb2010, bctcb2010 AS geoid, bctcb2010 AS id, (ct2010::float / 100)::text || ' - ' || cb2010 as geolabel FROM nyc_census_blocks"
     }
   ]
 }

--- a/data/sources/citibike-stations.json
+++ b/data/sources/citibike-stations.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "citibike-stations",
-      "sql": "SELECT the_geom_webmercator, station::json->>'name' AS name, station::json->>'capacity' AS capacity, station::json->>'bikes_available' AS bikes_available, station::json->>'docks_available' AS docks_available FROM twg_i75aydysqbrqk9zgvg WHERE station::json->>'capacity' <> '0'"
+      "sql": "SELECT the_geom_webmercator, station::json->>'name' AS name, station::json->>'capacity' AS capacity, station::json->>'bikes_available' AS bikes_available, station::json->>'docks_available' AS docks_available FROM citibike_stations WHERE station::json->>'capacity' <> '0'"
     }
   ],
   "meta": {

--- a/data/sources/digital-citymap.json
+++ b/data/sources/digital-citymap.json
@@ -4,43 +4,43 @@
   "source-layers": [
     {
       "id": "bulkhead-lines",
-      "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_bulkheadlines_v1"
+      "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_bulkheadlines"
     },
     {
       "id": "arterials",
-      "sql": "SELECT the_geom_webmercator, route_type FROM citymap_arterials_v0"
+      "sql": "SELECT the_geom_webmercator, route_type FROM citymap_arterials"
     },
     {
       "id": "pierhead-lines",
-      "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_pierheadlines_v1"
+      "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_pierheadlines"
     },
     {
       "id": "amendments",
-      "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, extract(epoch from effective) as effective, status FROM citymap_amendments_v3 WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
+      "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, extract(epoch from effective) as effective, status FROM citymap_amendments WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
     },
     {
       "id": "street-centerlines",
-      "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty, feature_st FROM citymap_streetcenterlines_v1"
+      "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty, feature_st FROM citymap_streetcenterlines"
     },
     {
       "id": "citymap",
-      "sql": "SELECT the_geom_webmercator, type, boro_nm FROM citymap_citymap_v1"
+      "sql": "SELECT the_geom_webmercator, type, boro_nm FROM citymap_citymap"
     },
     {
       "id": "name-changes-points",
-      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_points_v0"
+      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_points"
     },
     {
       "id": "name-changes-lines",
-      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_streets_v0"
+      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_streets"
     },
     {
       "id": "name-changes-areas",
-      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas_v0"
+      "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas"
     },
     {
       "id": "rail-lines",
-      "sql": "SELECT the_geom_webmercator, street FROM citymap_rails_v0"
+      "sql": "SELECT the_geom_webmercator, street FROM citymap_rails"
     }
   ],
   "meta": {

--- a/data/sources/effective-flood-insurance-rate-2007.json
+++ b/data/sources/effective-flood-insurance-rate-2007.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "effective-flood-insurance-rate-2007",
-      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
+      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
     }
   ],
   "minzoom": 0,

--- a/data/sources/ferries.json
+++ b/data/sources/ferries.json
@@ -4,11 +4,11 @@
   "source-layers": [
     {
       "id": "ferry-routes",
-      "sql": "SELECT the_geom_webmercator, cartodb_id, route_name FROM nyc_ferry_routes_v20181023"
+      "sql": "SELECT the_geom_webmercator, cartodb_id, route_name FROM nyc_ferry_routes"
     },
     {
       "id": "ferry-landings",
-      "sql": "SELECT the_geom_webmercator, name, link FROM nyc_ferry_landings_v20181023 WHERE status <> 'Inactive'"
+      "sql": "SELECT the_geom_webmercator, name, link FROM nyc_ferry_landings WHERE status <> 'Inactive'"
     }
   ],
   "minzoom": 0,

--- a/data/sources/floodplains.json
+++ b/data/sources/floodplains.json
@@ -4,11 +4,11 @@
   "source-layers": [
     {
       "id": "effective-flood-insurance-rate-2007",
-      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
+      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
     },
     {
       "id": "preliminary-flood-insurance-rate",
-      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' "
+      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' "
     }
   ],
   "meta": {

--- a/data/sources/landmark-historic.json
+++ b/data/sources/landmark-historic.json
@@ -4,15 +4,15 @@
   "source-layers": [
     {
       "id": "historic-districts",
-      "sql": "SELECT the_geom_webmercator, area_name FROM historic_districts_lpc_v20180501 WHERE status_of = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, area_name FROM historic_districts_lpc WHERE status_of = 'DESIGNATED'"
     },
     {
       "id": "landmarks",
-      "sql": "SELECT the_geom_webmercator, lm_name, lm_type FROM individual_landmarks_lpc_v20180501 WHERE (lm_type = 'Individual Landmark' OR lm_type = 'Interior Landmark') AND last_actio = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, lm_name, lm_type FROM individual_landmarks_lpc WHERE (lm_type = 'Individual Landmark' OR lm_type = 'Interior Landmark') AND last_actio = 'DESIGNATED'"
     },
     {
       "id": "scenic-landmarks",
-      "sql": "SELECT the_geom_webmercator, scen_lm_na FROM scenic_landmarks_lpc_v20180501 WHERE last_actio = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, scen_lm_na FROM scenic_landmarks_lpc WHERE last_actio = 'DESIGNATED'"
     }
   ],
   "minzoom": 0,

--- a/data/sources/paws.json
+++ b/data/sources/paws.json
@@ -4,19 +4,19 @@
   "source-layers": [
     {
       "id": "wpaas",
-      "sql": "SELECT the_geom_webmercator, cartodb_id, paws_id, name, feature_promenade_esplanade, feature_seating_lawn, feature_pier, feature_wetland_natural_edge, feature_dog_run, feature_educational_or_interpretive, feature_public_restroom, feature_shade_structure, feature_outdoor_art, feature_food_or_beverage_concessions, feature_group_seating, activity_volleyball_court, activity_basketball_court, activity_fishing, activity_boating_access, activity_tot_playground, activity_splash_feature, activity_other_recreational_facilities, activity_swimming, constructi FROM planninglabs.wpaas_v201811"
+      "sql": "SELECT the_geom_webmercator, cartodb_id, paws_id, name, feature_promenade_esplanade, feature_seating_lawn, feature_pier, feature_wetland_natural_edge, feature_dog_run, feature_educational_or_interpretive, feature_public_restroom, feature_shade_structure, feature_outdoor_art, feature_food_or_beverage_concessions, feature_group_seating, activity_volleyball_court, activity_basketball_court, activity_fishing, activity_boating_access, activity_tot_playground, activity_splash_feature, activity_other_recreational_facilities, activity_swimming, constructi FROM planninglabs.wpaas"
     },
     {
       "id": "publiclyownedwaterfront",
-      "sql": "SELECT the_geom_webmercator, cartodb_id, wf_park_id, park_name, link, agency, status FROM publiclyownedwaterfront_v201810"
+      "sql": "SELECT the_geom_webmercator, cartodb_id, wf_park_id, park_name, link, agency, status FROM publiclyownedwaterfront"
     },
     {
       "id": "paws_footprints",
-      "sql": "SELECT a.the_geom_webmercator, a.cartodb_id, a.paws_id, b.feature_promenade_esplanade, b.feature_seating_lawn, b.feature_pier, b.feature_wetland_natural_edge, b.feature_dog_run, b.feature_educational_or_interpretive, b.feature_public_restroom, b.feature_shade_structure, b.feature_outdoor_art, b.feature_food_or_beverage_concessions, b.feature_group_seating, b.activity_volleyball_court, b.activity_basketball_court, b.activity_fishing, b.activity_boating_access, b.activity_tot_playground, b.activity_splash_feature, b.activity_other_recreational_facilities, b.activity_swimming, b.constructi FROM wpaas_footprints_v201810 AS a LEFT JOIN planninglabs.wpaas_v201811 b ON a.paws_id = b.paws_id::text"
+      "sql": "SELECT a.the_geom_webmercator, a.cartodb_id, a.paws_id, b.feature_promenade_esplanade, b.feature_seating_lawn, b.feature_pier, b.feature_wetland_natural_edge, b.feature_dog_run, b.feature_educational_or_interpretive, b.feature_public_restroom, b.feature_shade_structure, b.feature_outdoor_art, b.feature_food_or_beverage_concessions, b.feature_group_seating, b.activity_volleyball_court, b.activity_basketball_court, b.activity_fishing, b.activity_boating_access, b.activity_tot_playground, b.activity_splash_feature, b.activity_other_recreational_facilities, b.activity_swimming, b.constructi FROM wpaas_footprints AS a LEFT JOIN planninglabs.wpaas b ON a.paws_id = b.paws_id::text"
     },
     {
       "id": "paws_entry_points",
-      "sql": "SELECT the_geom_webmercator, cartodb_id FROM wpaas_accesspoints_v201810"
+      "sql": "SELECT the_geom_webmercator, cartodb_id FROM wpaas_accesspoints"
     }
   ],
   "meta": {

--- a/data/sources/preliminary-flood-insurance-rate.json
+++ b/data/sources/preliminary-flood-insurance-rate.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "preliminary-flood-insurance-rate",
-      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
+      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
     }
   ],
   "minzoom": 0,

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "inclusionary-housing",
-      "sql": "SELECT the_geom_webmercator, projectnam FROM inclusionary_housing_v201804"
+      "sql": "SELECT the_geom_webmercator, projectnam FROM inclusionary_housing"
     },
     {
       "id": "transit-zones",
@@ -28,7 +28,7 @@
     },
     {
       "id": "fresh",
-      "sql": "SELECT the_geom_webmercator, name FROM fresh_zones_v201611"
+      "sql": "SELECT the_geom_webmercator, name FROM fresh_zones"
     },
     {
       "id": "sidewalk-cafes",
@@ -36,11 +36,11 @@
     },
     {
       "id": "low-density-growth-mgmt-areas",
-      "sql": "SELECT the_geom_webmercator FROM lower_density_growth_management_areas_v201709"
+      "sql": "SELECT the_geom_webmercator FROM lower_density_growth_management_areas"
     },
     {
       "id": "coastal-zone-boundary",
-      "sql": "SELECT the_geom_webmercator FROM coastal_zone_boundary_v201601"
+      "sql": "SELECT the_geom_webmercator FROM coastal_zone_boundary"
     },
     {
       "id": "waterfront-access-plan",
@@ -52,7 +52,7 @@
     },
     {
       "id": "business-improvement-districts",
-      "sql": "SELECT the_geom_webmercator, bid FROM business_improvement_districts_v0"
+      "sql": "SELECT the_geom_webmercator, bid FROM business_improvement_districts"
     },
     {
       "id": "e-designations",
@@ -60,11 +60,11 @@
     },
     {
       "id": "industrial-business-zones",
-      "sql": "SELECT the_geom_webmercator, name FROM industrial_business_zones_v20180501"
+      "sql": "SELECT the_geom_webmercator, name FROM industrial_business_zones"
     },
     {
       "id": "appendixj-designated-mdistricts",
-      "sql": "SELECT the_geom_webmercator, name, subarea FROM appendixj_designated_mdistricts_v201712"
+      "sql": "SELECT the_geom_webmercator, name, subarea FROM appendixj_designated_mdistricts"
     }
     ],
     "meta": {

--- a/data/sources/transportation.json
+++ b/data/sources/transportation.json
@@ -4,27 +4,27 @@
   "source-layers": [
     {
       "id": "bike-routes",
-      "sql": "SELECT the_geom_webmercator, cartodb_id FROM bike_routes_v20180913"
+      "sql": "SELECT the_geom_webmercator, cartodb_id FROM bike_routes"
     },
     {
       "id": "subway-routes",
-      "sql": "SELECT the_geom_webmercator, rt_symbol FROM mta_subway_routes_v0"
+      "sql": "SELECT the_geom_webmercator, rt_symbol FROM mta_subway_routes"
     },
     {
       "id": "subway-stops",
-      "sql": "SELECT the_geom_webmercator, name FROM mta_subway_stops_v0"
+      "sql": "SELECT the_geom_webmercator, name FROM mta_subway_stops"
     },
     {
       "id": "subway-entrances",
-      "sql": "SELECT the_geom_webmercator, cartodb_id FROM mta_subway_entrances_v0"
+      "sql": "SELECT the_geom_webmercator, cartodb_id FROM mta_subway_entrances"
     }
   ],
   "minzoom": 0,
   "meta": {
     "description": "NYC Subway Lines and Stops - Originally Sourced from NYC DoITT GIS, combined with SI Railway data from Baruch College NYC Mass Transit Spatial Layers | Subway entrances from NYC Open Data",
     "url": [
-      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_stops_v0&format=SHP",
-      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_routes_v0&format=SHP",
+      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_stops&format=SHP",
+      "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_routes&format=SHP",
       "https://data.cityofnewyork.us/Transportation/Subway-Entrances/drex-xx56",
       "https://www.baruch.cuny.edu/confluence/display/geoportal/NYC+Mass+Transit+Spatial+Layers"
     ],

--- a/scripts/create-carto-aliases.sql
+++ b/scripts/create-carto-aliases.sql
@@ -1,0 +1,314 @@
+-- These commands should be run in the Carto UI when new source data tables are uploaded
+
+-- Implemented
+DROP VIEW IF EXISTS mappluto;
+CREATE VIEW mappluto AS
+	(SELECT * FROM mappluto_18v2);
+GRANT SELECT ON mappluto TO publicuser;
+
+DROP VIEW IF EXISTS facdb;
+CREATE VIEW facdb AS
+	(SELECT * FROM facdb_v201811);
+GRANT SELECT ON facdb TO publicuser;
+
+DROP VIEW IF EXISTS mandatory_inclusionary_housing;
+CREATE VIEW mandatory_inclusionary_housing AS
+	(SELECT * FROM mandatory_inclusionary_housing_v201902);
+GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;
+
+DROP VIEW IF EXISTS e_designations;
+CREATE VIEW e_designations AS
+	(SELECT * FROM e_designations_v201902);
+GRANT SELECT ON e_designations TO publicuser;
+
+DROP VIEW IF EXISTS commercial_overlays;
+CREATE VIEW commercial_overlays AS
+	(SELECT * FROM commercial_overlays_v201902);
+GRANT SELECT ON commercial_overlays TO publicuser;
+
+DROP VIEW IF EXISTS limited_height_districts;
+CREATE VIEW limited_height_districts AS
+	(SELECT * FROM limited_height_districts_v201902);
+GRANT SELECT ON limited_height_districts TO publicuser;
+
+DROP VIEW IF EXISTS special_purpose_districts;
+CREATE VIEW special_purpose_districts AS
+	(SELECT * FROM special_purpose_districts_v201902);
+GRANT SELECT ON special_purpose_districts TO publicuser;
+
+DROP VIEW IF EXISTS special_purpose_subdistricts;
+CREATE VIEW special_purpose_subdistricts AS
+	(SELECT * FROM special_purpose_subdistricts_v201902);
+GRANT SELECT ON special_purpose_subdistricts TO publicuser;
+
+DROP VIEW IF EXISTS zoning_districts;
+CREATE VIEW zoning_districts AS
+	(SELECT * FROM zoning_districts_v201902);
+GRANT SELECT ON zoning_districts TO publicuser;
+
+DROP VIEW IF EXISTS zoning_map_amendments;
+CREATE VIEW zoning_map_amendments AS
+	(SELECT * FROM zoning_map_amendments_v201902);
+GRANT SELECT ON zoning_map_amendments TO publicuser;
+
+DROP VIEW IF EXISTS sidewalk_cafes;
+CREATE VIEW sidewalk_cafes AS
+	(SELECT * FROM sidewalk_cafes_v201902);
+GRANT SELECT ON sidewalk_cafes TO publicuser;
+
+DROP VIEW IF EXISTS transitzones;
+CREATE VIEW transitzones AS
+	(SELECT * FROM transitzones_v201902);
+GRANT SELECT ON transitzones TO publicuser;
+
+DROP VIEW IF EXISTS waterfront_access_plan;
+CREATE VIEW waterfront_access_plan AS
+	(SELECT * FROM waterfront_access_plan_v201902);
+GRANT SELECT ON waterfront_access_plan TO publicuser;
+
+DROP VIEW IF EXISTS community_districts;
+CREATE VIEW community_districts AS
+	(SELECT * FROM community_districts_v201811);
+GRANT SELECT ON community_districts TO publicuser;
+
+-- New
+DROP VIEW IF EXISTS nta_boundaries;
+CREATE VIEW nta_boundaries AS
+	(SELECT * FROM nta_boundaries_v201811);
+GRANT SELECT ON nta_boundaries TO publicuser;
+
+DROP VIEW IF EXISTS merged_pfirm_firm_500yr;
+CREATE VIEW merged_pfirm_firm_500yr AS
+	(SELECT * FROM merged_pfirm_firm_500yr_v201901);
+GRANT SELECT ON merged_pfirm_firm_500yr TO publicuser;
+
+DROP VIEW IF EXISTS merged_pfirm_firm_100yr;
+CREATE VIEW merged_pfirm_firm_100yr AS
+	(SELECT * FROM merged_pfirm_firm_100yr_v201901);
+GRANT SELECT ON merged_pfirm_firm_100yr TO publicuser;
+
+DROP VIEW IF EXISTS cd_floodplains;
+CREATE VIEW cd_floodplains AS
+	(SELECT * FROM cd_floodplains_v201902);
+GRANT SELECT ON cd_floodplains TO publicuser;
+
+-- Future
+DROP VIEW IF EXISTS appendixj_designated_mdistricts;
+CREATE VIEW appendixj_designated_mdistricts AS
+	(SELECT * FROM appendixj_designated_mdistricts_v201712);
+GRANT SELECT ON appendixj_designated_mdistricts TO publicuser;
+
+DROP VIEW IF EXISTS bike_routes;
+CREATE VIEW bike_routes AS
+	(SELECT * FROM bike_routes_v20180913);
+GRANT SELECT ON bike_routes TO publicuser;
+
+DROP VIEW IF EXISTS bk_qn_mh_boundary;
+CREATE VIEW bk_qn_mh_boundary AS
+	(SELECT * FROM bk_qn_mh_boundary_v201804);
+GRANT SELECT ON bk_qn_mh_boundary TO publicuser;
+
+DROP VIEW IF EXISTS boro_boundaries;
+CREATE VIEW boro_boundaries AS
+	(SELECT * FROM boro_boundaries_V201811);
+GRANT SELECT ON boro_boundaries TO publicuser;
+
+DROP VIEW IF EXISTS business_improvement_districts;
+CREATE VIEW business_improvement_districts AS
+	(SELECT * FROM business_improvement_districts_v0);
+GRANT SELECT ON business_improvement_districts TO publicuser;
+
+DROP VIEW IF EXISTS citymap_amendments;
+CREATE VIEW citymap_amendments AS
+	(SELECT * FROM citymap_amendments_v3);
+GRANT SELECT ON citymap_amendments TO publicuser;
+
+DROP VIEW IF EXISTS citymap_arterials;
+CREATE VIEW citymap_arterials AS
+	(SELECT * FROM citymap_arterials_v0);
+GRANT SELECT ON citymap_arterials TO publicuser;
+
+DROP VIEW IF EXISTS citymap_bulkheadlines;
+CREATE VIEW citymap_bulkheadlines AS
+	(SELECT * FROM citymap_bulkheadlines_v1);
+GRANT SELECT ON citymap_bulkheadlines TO publicuser;
+
+DROP VIEW IF EXISTS citymap_citymap;
+CREATE VIEW citymap_citymap AS
+	(SELECT * FROM citymap_citymap_v1);
+GRANT SELECT ON citymap_citymap TO publicuser;
+
+DROP VIEW IF EXISTS citymap_pierheadlines;
+CREATE VIEW citymap_pierheadlines AS
+	(SELECT * FROM citymap_pierheadlines_v1);
+GRANT SELECT ON citymap_pierheadlines TO publicuser;
+
+DROP VIEW IF EXISTS citymap_rails;
+CREATE VIEW citymap_rails AS
+	(SELECT * FROM citymap_rails_v0);
+GRANT SELECT ON citymap_rails TO publicuser;
+
+DROP VIEW IF EXISTS citymap_streetcenterlines;
+CREATE VIEW citymap_streetcenterlines AS
+	(SELECT * FROM citymap_streetcenterlines_v1);
+GRANT SELECT ON citymap_streetcenterlines TO publicuser;
+
+DROP VIEW IF EXISTS citymap_streetnamechanges_areas ;
+CREATE VIEW citymap_streetnamechanges_areas  AS
+	(SELECT * FROM citymap_streetnamechanges_areas_v0 );
+GRANT SELECT ON citymap_streetnamechanges_areas  TO publicuser;
+
+DROP VIEW IF EXISTS citymap_streetnamechanges_points;
+CREATE VIEW citymap_streetnamechanges_points AS
+	(SELECT * FROM citymap_streetnamechanges_points_v0);
+GRANT SELECT ON citymap_streetnamechanges_points TO publicuser;
+
+DROP VIEW IF EXISTS citymap_streetnamechanges_streets;
+CREATE VIEW citymap_streetnamechanges_streets AS
+	(SELECT * FROM citymap_streetnamechanges_streets_v0);
+GRANT SELECT ON citymap_streetnamechanges_streets TO publicuser;
+
+DROP VIEW IF EXISTS coastal_zone_boundary;
+CREATE VIEW coastal_zone_boundary AS
+	(SELECT * FROM coastal_zone_boundary_v201601);
+GRANT SELECT ON coastal_zone_boundary TO publicuser;
+
+DROP VIEW IF EXISTS community_districts;
+CREATE VIEW community_districts AS
+	(SELECT * FROM community_districts_v201811);
+GRANT SELECT ON community_districts TO publicuser;
+
+DROP VIEW IF EXISTS floodplain_firm2007;
+CREATE VIEW floodplain_firm2007 AS
+	(SELECT * FROM floodplain_firm2007_v0);
+GRANT SELECT ON floodplain_firm2007 TO publicuser;
+
+DROP VIEW IF EXISTS floodplain_pfirm2015;
+CREATE VIEW floodplain_pfirm2015 AS
+	(SELECT * FROM floodplain_pfirm2015_v0);
+GRANT SELECT ON floodplain_pfirm2015 TO publicuser;
+
+DROP VIEW IF EXISTS fresh_zones;
+CREATE VIEW fresh_zones AS
+	(SELECT * FROM fresh_zones_v201611);
+GRANT SELECT ON fresh_zones TO publicuser;
+
+DROP VIEW IF EXISTS historic_districts_lpc;
+CREATE VIEW historic_districts_lpc AS
+	(SELECT * FROM historic_districts_lpc_v20180501);
+GRANT SELECT ON historic_districts_lpc TO publicuser;
+
+DROP VIEW IF EXISTS humanboatlaunch;
+CREATE VIEW humanboatlaunch AS
+	(SELECT * FROM humanboatlaunch_v201810);
+GRANT SELECT ON humanboatlaunch TO publicuser;
+
+DROP VIEW IF EXISTS inclusionary_housing;
+CREATE VIEW inclusionary_housing AS
+	(SELECT * FROM inclusionary_housing_v201804);
+GRANT SELECT ON inclusionary_housing TO publicuser;
+
+DROP VIEW IF EXISTS individual_landmarks_lpc;
+CREATE VIEW individual_landmarks_lpc AS
+	(SELECT * FROM individual_landmarks_lpc_v20180501);
+GRANT SELECT ON individual_landmarks_lpc TO publicuser;
+
+DROP VIEW IF EXISTS industrial_business_zones;
+CREATE VIEW industrial_business_zones AS
+	(SELECT * FROM industrial_business_zones_v20180501);
+GRANT SELECT ON industrial_business_zones TO publicuser;
+
+DROP VIEW IF EXISTS lower_density_growth_management_areas;
+CREATE VIEW lower_density_growth_management_areas AS
+	(SELECT * FROM lower_density_growth_management_areas_v201709);
+GRANT SELECT ON lower_density_growth_management_areas TO publicuser;
+
+DROP VIEW IF EXISTS mta_subway_entrances;
+CREATE VIEW mta_subway_entrances AS
+	(SELECT * FROM mta_subway_entrances_v0);
+GRANT SELECT ON mta_subway_entrances TO publicuser;
+
+DROP VIEW IF EXISTS mta_subway_routes;
+CREATE VIEW mta_subway_routes AS
+	(SELECT * FROM mta_subway_routes_v0);
+GRANT SELECT ON mta_subway_routes TO publicuser;
+
+DROP VIEW IF EXISTS mta_subway_stops;
+CREATE VIEW mta_subway_stops AS
+	(SELECT * FROM mta_subway_stops_v0);
+GRANT SELECT ON mta_subway_stops TO publicuser;
+
+DROP VIEW IF EXISTS ny_assembly_districts;
+CREATE VIEW ny_assembly_districts AS
+	(SELECT * FROM ny_assembly_districts_v201811);
+GRANT SELECT ON ny_assembly_districts TO publicuser;
+
+DROP VIEW IF EXISTS ny_senate_districts;
+CREATE VIEW ny_senate_districts AS
+	(SELECT * FROM ny_senate_districts_v201811);
+GRANT SELECT ON ny_senate_districts TO publicuser;
+
+DROP VIEW IF EXISTS nyc_census_blocks;
+CREATE VIEW nyc_census_blocks AS
+	(SELECT * FROM nyc_census_blocks_2010);
+GRANT SELECT ON nyc_census_blocks TO publicuser;
+
+DROP VIEW IF EXISTS nyc_census_tracts;
+CREATE VIEW nyc_census_tracts AS
+	(SELECT * FROM nyc_census_tracts_2010);
+GRANT SELECT ON nyc_census_tracts TO publicuser;
+
+DROP VIEW IF EXISTS nyc_council_districts;
+CREATE VIEW nyc_council_districts AS
+	(SELECT * FROM nyc_council_districts_v201811);
+GRANT SELECT ON nyc_council_districts TO publicuser;
+
+DROP VIEW IF EXISTS nyc_ferry_landings;
+CREATE VIEW nyc_ferry_landings AS
+	(SELECT * FROM nyc_ferry_landings_v20181023);
+GRANT SELECT ON nyc_ferry_landings TO publicuser;
+
+DROP VIEW IF EXISTS nyc_ferry_routes;
+CREATE VIEW nyc_ferry_routes AS
+	(SELECT * FROM nyc_ferry_routes_v20181023);
+GRANT SELECT ON nyc_ferry_routes TO publicuser;
+
+DROP VIEW IF EXISTS nyc_pumas;
+CREATE VIEW nyc_pumas AS
+	(SELECT * FROM nyc_pumas_v201811);
+GRANT SELECT ON nyc_pumas TO publicuser;
+
+DROP VIEW IF EXISTS publiclyownedwaterfront;
+CREATE VIEW publiclyownedwaterfront AS
+	(SELECT * FROM publiclyownedwaterfront_v201810);
+GRANT SELECT ON publiclyownedwaterfront TO publicuser;
+
+DROP VIEW IF EXISTS scenic_landmarks_lpc;
+CREATE VIEW scenic_landmarks_lpc AS
+	(SELECT * FROM scenic_landmarks_lpc_v20180501);
+GRANT SELECT ON scenic_landmarks_lpc TO publicuser;
+
+DROP VIEW IF EXISTS citibike_stations;
+CREATE VIEW citibike_stations AS
+	(SELECT * FROM twg_i75aydysqbrqk9zgvg);
+GRANT SELECT ON citibike_stations TO publicuser;
+
+DROP VIEW IF EXISTS wpaas_accesspoints;
+CREATE VIEW wpaas_accesspoints AS
+	(SELECT * FROM wpaas_accesspoints_v201810);
+GRANT SELECT ON wpaas_accesspoints TO publicuser;
+
+DROP VIEW IF EXISTS wpaas_footprints;
+CREATE VIEW wpaas_footprints AS
+	(SELECT * FROM wpaas_footprints_v201810);
+GRANT SELECT ON wpaas_footprints TO publicuser;
+
+DROP VIEW IF EXISTS wpaas;
+CREATE VIEW wpaas AS
+	(SELECT * FROM wpaas_v201811);
+GRANT SELECT ON wpaas TO publicuser;
+
+DROP VIEW IF EXISTS upland_waterfront_areas;
+CREATE VIEW upland_waterfront_areas AS
+	(SELECT * FROM upland_waterfront_areas_v200912);
+GRANT SELECT ON upland_waterfront_areas TO publicuser;

--- a/scripts/create-carto-aliases.sql
+++ b/scripts/create-carto-aliases.sql
@@ -1,314 +1,479 @@
--- These commands should be run in the Carto UI when new source data tables are uploaded
+-- You can query to see all views that exist in Carto using this SQL: 
+-- SELECT viewname, definition FROM pg_views WHERE schemaname = 'planninglabs' ORDER BY viewname
 
--- Implemented
-DROP VIEW IF EXISTS mappluto;
-CREATE VIEW mappluto AS
-	(SELECT * FROM mappluto_18v2);
-GRANT SELECT ON mappluto TO publicuser;
+-- When a new source data table is uploaded on Carto, these commands can be updated accordingly and run in the Carto UI to redefine the view. Please note that this list includes tables that aren't actually consumed in the layers-API, but they're included here for record keeping of all views that are available.
 
-DROP VIEW IF EXISTS facdb;
-CREATE VIEW facdb AS
-	(SELECT * FROM facdb_v201811);
-GRANT SELECT ON facdb TO publicuser;
-
-DROP VIEW IF EXISTS mandatory_inclusionary_housing;
-CREATE VIEW mandatory_inclusionary_housing AS
-	(SELECT * FROM mandatory_inclusionary_housing_v201902);
-GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;
-
-DROP VIEW IF EXISTS e_designations;
-CREATE VIEW e_designations AS
-	(SELECT * FROM e_designations_v201902);
-GRANT SELECT ON e_designations TO publicuser;
-
-DROP VIEW IF EXISTS commercial_overlays;
-CREATE VIEW commercial_overlays AS
-	(SELECT * FROM commercial_overlays_v201902);
-GRANT SELECT ON commercial_overlays TO publicuser;
-
-DROP VIEW IF EXISTS limited_height_districts;
-CREATE VIEW limited_height_districts AS
-	(SELECT * FROM limited_height_districts_v201902);
-GRANT SELECT ON limited_height_districts TO publicuser;
-
-DROP VIEW IF EXISTS special_purpose_districts;
-CREATE VIEW special_purpose_districts AS
-	(SELECT * FROM special_purpose_districts_v201902);
-GRANT SELECT ON special_purpose_districts TO publicuser;
-
-DROP VIEW IF EXISTS special_purpose_subdistricts;
-CREATE VIEW special_purpose_subdistricts AS
-	(SELECT * FROM special_purpose_subdistricts_v201902);
-GRANT SELECT ON special_purpose_subdistricts TO publicuser;
-
-DROP VIEW IF EXISTS zoning_districts;
-CREATE VIEW zoning_districts AS
-	(SELECT * FROM zoning_districts_v201902);
-GRANT SELECT ON zoning_districts TO publicuser;
-
-DROP VIEW IF EXISTS zoning_map_amendments;
-CREATE VIEW zoning_map_amendments AS
-	(SELECT * FROM zoning_map_amendments_v201902);
-GRANT SELECT ON zoning_map_amendments TO publicuser;
-
-DROP VIEW IF EXISTS sidewalk_cafes;
-CREATE VIEW sidewalk_cafes AS
-	(SELECT * FROM sidewalk_cafes_v201902);
-GRANT SELECT ON sidewalk_cafes TO publicuser;
-
-DROP VIEW IF EXISTS transitzones;
-CREATE VIEW transitzones AS
-	(SELECT * FROM transitzones_v201902);
-GRANT SELECT ON transitzones TO publicuser;
-
-DROP VIEW IF EXISTS waterfront_access_plan;
-CREATE VIEW waterfront_access_plan AS
-	(SELECT * FROM waterfront_access_plan_v201902);
-GRANT SELECT ON waterfront_access_plan TO publicuser;
-
-DROP VIEW IF EXISTS community_districts;
-CREATE VIEW community_districts AS
-	(SELECT * FROM community_districts_v201811);
-GRANT SELECT ON community_districts TO publicuser;
-
--- New
-DROP VIEW IF EXISTS nta_boundaries;
-CREATE VIEW nta_boundaries AS
-	(SELECT * FROM nta_boundaries_v201811);
-GRANT SELECT ON nta_boundaries TO publicuser;
-
-DROP VIEW IF EXISTS merged_pfirm_firm_500yr;
-CREATE VIEW merged_pfirm_firm_500yr AS
-	(SELECT * FROM merged_pfirm_firm_500yr_v201901);
-GRANT SELECT ON merged_pfirm_firm_500yr TO publicuser;
-
-DROP VIEW IF EXISTS merged_pfirm_firm_100yr;
-CREATE VIEW merged_pfirm_firm_100yr AS
-	(SELECT * FROM merged_pfirm_firm_100yr_v201901);
-GRANT SELECT ON merged_pfirm_firm_100yr TO publicuser;
-
-DROP VIEW IF EXISTS cd_floodplains;
-CREATE VIEW cd_floodplains AS
-	(SELECT * FROM cd_floodplains_v201902);
-GRANT SELECT ON cd_floodplains TO publicuser;
-
--- Future
 DROP VIEW IF EXISTS appendixj_designated_mdistricts;
-CREATE VIEW appendixj_designated_mdistricts AS
+CREATE VIEW appendixj_designated_mdistricts AS 
 	(SELECT * FROM appendixj_designated_mdistricts_v201712);
 GRANT SELECT ON appendixj_designated_mdistricts TO publicuser;
 
 DROP VIEW IF EXISTS bike_routes;
-CREATE VIEW bike_routes AS
+CREATE VIEW bike_routes AS 
 	(SELECT * FROM bike_routes_v20180913);
 GRANT SELECT ON bike_routes TO publicuser;
 
 DROP VIEW IF EXISTS bk_qn_mh_boundary;
-CREATE VIEW bk_qn_mh_boundary AS
+CREATE VIEW bk_qn_mh_boundary AS 
 	(SELECT * FROM bk_qn_mh_boundary_v201804);
 GRANT SELECT ON bk_qn_mh_boundary TO publicuser;
 
 DROP VIEW IF EXISTS boro_boundaries;
-CREATE VIEW boro_boundaries AS
+CREATE VIEW boro_boundaries AS 
 	(SELECT * FROM boro_boundaries_V201811);
 GRANT SELECT ON boro_boundaries TO publicuser;
 
 DROP VIEW IF EXISTS business_improvement_districts;
-CREATE VIEW business_improvement_districts AS
+CREATE VIEW business_improvement_districts AS 
 	(SELECT * FROM business_improvement_districts_v0);
 GRANT SELECT ON business_improvement_districts TO publicuser;
 
+DROP VIEW IF EXISTS cd_floodplains;
+CREATE VIEW cd_floodplains AS 
+	(SELECT * FROM cd_floodplains_v201902);
+GRANT SELECT ON cd_floodplains TO publicuser;
+
+DROP VIEW IF EXISTS citibike_stations;
+CREATE VIEW citibike_stations AS 
+	(SELECT * FROM twg_i75aydysqbrqk9zgvg);
+GRANT SELECT ON citibike_stations TO publicuser;
+
 DROP VIEW IF EXISTS citymap_amendments;
-CREATE VIEW citymap_amendments AS
+CREATE VIEW citymap_amendments AS 
 	(SELECT * FROM citymap_amendments_v3);
 GRANT SELECT ON citymap_amendments TO publicuser;
 
 DROP VIEW IF EXISTS citymap_arterials;
-CREATE VIEW citymap_arterials AS
+CREATE VIEW citymap_arterials AS 
 	(SELECT * FROM citymap_arterials_v0);
 GRANT SELECT ON citymap_arterials TO publicuser;
 
 DROP VIEW IF EXISTS citymap_bulkheadlines;
-CREATE VIEW citymap_bulkheadlines AS
+CREATE VIEW citymap_bulkheadlines AS 
 	(SELECT * FROM citymap_bulkheadlines_v1);
 GRANT SELECT ON citymap_bulkheadlines TO publicuser;
 
 DROP VIEW IF EXISTS citymap_citymap;
-CREATE VIEW citymap_citymap AS
+CREATE VIEW citymap_citymap AS 
 	(SELECT * FROM citymap_citymap_v1);
 GRANT SELECT ON citymap_citymap TO publicuser;
 
 DROP VIEW IF EXISTS citymap_pierheadlines;
-CREATE VIEW citymap_pierheadlines AS
+CREATE VIEW citymap_pierheadlines AS 
 	(SELECT * FROM citymap_pierheadlines_v1);
 GRANT SELECT ON citymap_pierheadlines TO publicuser;
 
 DROP VIEW IF EXISTS citymap_rails;
-CREATE VIEW citymap_rails AS
+CREATE VIEW citymap_rails AS 
 	(SELECT * FROM citymap_rails_v0);
 GRANT SELECT ON citymap_rails TO publicuser;
 
 DROP VIEW IF EXISTS citymap_streetcenterlines;
-CREATE VIEW citymap_streetcenterlines AS
+CREATE VIEW citymap_streetcenterlines AS 
 	(SELECT * FROM citymap_streetcenterlines_v1);
 GRANT SELECT ON citymap_streetcenterlines TO publicuser;
 
-DROP VIEW IF EXISTS citymap_streetnamechanges_areas ;
-CREATE VIEW citymap_streetnamechanges_areas  AS
-	(SELECT * FROM citymap_streetnamechanges_areas_v0 );
-GRANT SELECT ON citymap_streetnamechanges_areas  TO publicuser;
+DROP VIEW IF EXISTS citymap_streetnamechanges_areas;
+CREATE VIEW citymap_streetnamechanges_areas AS 
+	(SELECT * FROM citymap_streetnamechanges_areas_v0);
+GRANT SELECT ON citymap_streetnamechanges_areas TO publicuser;
 
 DROP VIEW IF EXISTS citymap_streetnamechanges_points;
-CREATE VIEW citymap_streetnamechanges_points AS
+CREATE VIEW citymap_streetnamechanges_points AS 
 	(SELECT * FROM citymap_streetnamechanges_points_v0);
 GRANT SELECT ON citymap_streetnamechanges_points TO publicuser;
 
 DROP VIEW IF EXISTS citymap_streetnamechanges_streets;
-CREATE VIEW citymap_streetnamechanges_streets AS
+CREATE VIEW citymap_streetnamechanges_streets AS 
 	(SELECT * FROM citymap_streetnamechanges_streets_v0);
 GRANT SELECT ON citymap_streetnamechanges_streets TO publicuser;
 
 DROP VIEW IF EXISTS coastal_zone_boundary;
-CREATE VIEW coastal_zone_boundary AS
+CREATE VIEW coastal_zone_boundary AS 
 	(SELECT * FROM coastal_zone_boundary_v201601);
 GRANT SELECT ON coastal_zone_boundary TO publicuser;
 
+DROP VIEW IF EXISTS commercial_overlays;
+CREATE VIEW commercial_overlays AS 
+	(SELECT * FROM commercial_overlays_v201902);
+GRANT SELECT ON commercial_overlays TO publicuser;
+
+DROP VIEW IF EXISTS community_district_profiles;
+CREATE VIEW community_district_profiles AS 
+	(SELECT * FROM community_district_profiles_v201902);
+GRANT SELECT ON community_district_profiles TO publicuser;
+
 DROP VIEW IF EXISTS community_districts;
-CREATE VIEW community_districts AS
+CREATE VIEW community_districts AS 
 	(SELECT * FROM community_districts_v201811);
 GRANT SELECT ON community_districts TO publicuser;
 
+DROP VIEW IF EXISTS e_designations;
+CREATE VIEW e_designations AS 
+	(SELECT * FROM e_designations_v201902);
+GRANT SELECT ON e_designations TO publicuser;
+
+DROP VIEW IF EXISTS facdb;
+CREATE VIEW facdb AS 
+	(SELECT * FROM facdb_v201811);
+GRANT SELECT ON facdb TO publicuser;
+
 DROP VIEW IF EXISTS floodplain_firm2007;
-CREATE VIEW floodplain_firm2007 AS
+CREATE VIEW floodplain_firm2007 AS 
 	(SELECT * FROM floodplain_firm2007_v0);
 GRANT SELECT ON floodplain_firm2007 TO publicuser;
 
 DROP VIEW IF EXISTS floodplain_pfirm2015;
-CREATE VIEW floodplain_pfirm2015 AS
+CREATE VIEW floodplain_pfirm2015 AS 
 	(SELECT * FROM floodplain_pfirm2015_v0);
 GRANT SELECT ON floodplain_pfirm2015 TO publicuser;
 
 DROP VIEW IF EXISTS fresh_zones;
-CREATE VIEW fresh_zones AS
+CREATE VIEW fresh_zones AS 
 	(SELECT * FROM fresh_zones_v201611);
 GRANT SELECT ON fresh_zones TO publicuser;
 
 DROP VIEW IF EXISTS historic_districts_lpc;
-CREATE VIEW historic_districts_lpc AS
+CREATE VIEW historic_districts_lpc AS 
 	(SELECT * FROM historic_districts_lpc_v20180501);
 GRANT SELECT ON historic_districts_lpc TO publicuser;
 
 DROP VIEW IF EXISTS humanboatlaunch;
-CREATE VIEW humanboatlaunch AS
+CREATE VIEW humanboatlaunch AS 
 	(SELECT * FROM humanboatlaunch_v201810);
 GRANT SELECT ON humanboatlaunch TO publicuser;
 
 DROP VIEW IF EXISTS inclusionary_housing;
-CREATE VIEW inclusionary_housing AS
+CREATE VIEW inclusionary_housing AS 
 	(SELECT * FROM inclusionary_housing_v201804);
 GRANT SELECT ON inclusionary_housing TO publicuser;
 
 DROP VIEW IF EXISTS individual_landmarks_lpc;
-CREATE VIEW individual_landmarks_lpc AS
+CREATE VIEW individual_landmarks_lpc AS 
 	(SELECT * FROM individual_landmarks_lpc_v20180501);
 GRANT SELECT ON individual_landmarks_lpc TO publicuser;
 
 DROP VIEW IF EXISTS industrial_business_zones;
-CREATE VIEW industrial_business_zones AS
+CREATE VIEW industrial_business_zones AS 
 	(SELECT * FROM industrial_business_zones_v20180501);
 GRANT SELECT ON industrial_business_zones TO publicuser;
 
+DROP VIEW IF EXISTS limited_height_districts;
+CREATE VIEW limited_height_districts AS 
+	(SELECT * FROM limited_height_districts_v201902);
+GRANT SELECT ON limited_height_districts TO publicuser;
+
 DROP VIEW IF EXISTS lower_density_growth_management_areas;
-CREATE VIEW lower_density_growth_management_areas AS
+CREATE VIEW lower_density_growth_management_areas AS 
 	(SELECT * FROM lower_density_growth_management_areas_v201709);
 GRANT SELECT ON lower_density_growth_management_areas TO publicuser;
 
+DROP VIEW IF EXISTS mandatory_inclusionary_housing;
+CREATE VIEW mandatory_inclusionary_housing AS 
+	(SELECT * FROM mandatory_inclusionary_housing_v201902);
+GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;
+
+DROP VIEW IF EXISTS mappluto;
+CREATE VIEW mappluto AS 
+	(SELECT * FROM mappluto_18v2);
+GRANT SELECT ON mappluto TO publicuser;
+
+DROP VIEW IF EXISTS merged_pfirm_firm_100yr;
+CREATE VIEW merged_pfirm_firm_100yr AS 
+	(SELECT * FROM merged_pfirm_firm_100yr_v201901);
+GRANT SELECT ON merged_pfirm_firm_100yr TO publicuser;
+
+DROP VIEW IF EXISTS merged_pfirm_firm_500yr;
+CREATE VIEW merged_pfirm_firm_500yr AS 
+	(SELECT * FROM merged_pfirm_firm_500yr_v201901);
+GRANT SELECT ON merged_pfirm_firm_500yr TO publicuser;
+
 DROP VIEW IF EXISTS mta_subway_entrances;
-CREATE VIEW mta_subway_entrances AS
+CREATE VIEW mta_subway_entrances AS 
 	(SELECT * FROM mta_subway_entrances_v0);
 GRANT SELECT ON mta_subway_entrances TO publicuser;
 
 DROP VIEW IF EXISTS mta_subway_routes;
-CREATE VIEW mta_subway_routes AS
+CREATE VIEW mta_subway_routes AS 
 	(SELECT * FROM mta_subway_routes_v0);
 GRANT SELECT ON mta_subway_routes TO publicuser;
 
 DROP VIEW IF EXISTS mta_subway_stops;
-CREATE VIEW mta_subway_stops AS
+CREATE VIEW mta_subway_stops AS 
 	(SELECT * FROM mta_subway_stops_v0);
 GRANT SELECT ON mta_subway_stops TO publicuser;
 
+DROP VIEW IF EXISTS nta_boundaries;
+CREATE VIEW nta_boundaries AS 
+	(SELECT * FROM nta_boundaries_v201811);
+GRANT SELECT ON nta_boundaries TO publicuser;
+
 DROP VIEW IF EXISTS ny_assembly_districts;
-CREATE VIEW ny_assembly_districts AS
+CREATE VIEW ny_assembly_districts AS 
 	(SELECT * FROM ny_assembly_districts_v201811);
 GRANT SELECT ON ny_assembly_districts TO publicuser;
 
 DROP VIEW IF EXISTS ny_senate_districts;
-CREATE VIEW ny_senate_districts AS
+CREATE VIEW ny_senate_districts AS 
 	(SELECT * FROM ny_senate_districts_v201811);
 GRANT SELECT ON ny_senate_districts TO publicuser;
 
 DROP VIEW IF EXISTS nyc_census_blocks;
-CREATE VIEW nyc_census_blocks AS
+CREATE VIEW nyc_census_blocks AS 
 	(SELECT * FROM nyc_census_blocks_2010);
 GRANT SELECT ON nyc_census_blocks TO publicuser;
 
 DROP VIEW IF EXISTS nyc_census_tracts;
-CREATE VIEW nyc_census_tracts AS
+CREATE VIEW nyc_census_tracts AS 
 	(SELECT * FROM nyc_census_tracts_2010);
 GRANT SELECT ON nyc_census_tracts TO publicuser;
 
 DROP VIEW IF EXISTS nyc_council_districts;
-CREATE VIEW nyc_council_districts AS
+CREATE VIEW nyc_council_districts AS 
 	(SELECT * FROM nyc_council_districts_v201811);
 GRANT SELECT ON nyc_council_districts TO publicuser;
 
 DROP VIEW IF EXISTS nyc_ferry_landings;
-CREATE VIEW nyc_ferry_landings AS
+CREATE VIEW nyc_ferry_landings AS 
 	(SELECT * FROM nyc_ferry_landings_v20181023);
 GRANT SELECT ON nyc_ferry_landings TO publicuser;
 
 DROP VIEW IF EXISTS nyc_ferry_routes;
-CREATE VIEW nyc_ferry_routes AS
+CREATE VIEW nyc_ferry_routes AS 
 	(SELECT * FROM nyc_ferry_routes_v20181023);
 GRANT SELECT ON nyc_ferry_routes TO publicuser;
 
 DROP VIEW IF EXISTS nyc_pumas;
-CREATE VIEW nyc_pumas AS
+CREATE VIEW nyc_pumas AS 
 	(SELECT * FROM nyc_pumas_v201811);
 GRANT SELECT ON nyc_pumas TO publicuser;
 
 DROP VIEW IF EXISTS publiclyownedwaterfront;
-CREATE VIEW publiclyownedwaterfront AS
+CREATE VIEW publiclyownedwaterfront AS 
 	(SELECT * FROM publiclyownedwaterfront_v201810);
 GRANT SELECT ON publiclyownedwaterfront TO publicuser;
 
+DROP VIEW IF EXISTS region_censustract;
+CREATE VIEW region_censustract AS 
+	(SELECT * FROM region_censustract_v0);
+GRANT SELECT ON region_censustract TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_industrial_dotdensity;
+CREATE VIEW region_censustract_industrial_dotdensity AS 
+	(SELECT * FROM region_censustract_industrial_dotdensity_v0);
+GRANT SELECT ON region_censustract_industrial_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_institution_dotdensity;
+CREATE VIEW region_censustract_institution_dotdensity AS 
+	(SELECT * FROM region_censustract_institution_dotdensity_v0);
+GRANT SELECT ON region_censustract_institution_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_localserv_dotdensity;
+CREATE VIEW region_censustract_localserv_dotdensity AS 
+	(SELECT * FROM region_censustract_localserv_dotdensity_v0);
+GRANT SELECT ON region_censustract_localserv_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_meta;
+CREATE VIEW region_censustract_meta AS 
+	(SELECT * FROM region_censustract_meta_v1);
+GRANT SELECT ON region_censustract_meta TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_office_dotdensity;
+CREATE VIEW region_censustract_office_dotdensity AS 
+	(SELECT * FROM region_censustract_office_dotdensity_v0);
+GRANT SELECT ON region_censustract_office_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_censustract_table;
+CREATE VIEW region_censustract_table AS 
+	(SELECT * FROM region_censustract_v1_table);
+GRANT SELECT ON region_censustract_table TO publicuser;
+
+DROP VIEW IF EXISTS region_commode_mnworkres_dotdensity;
+CREATE VIEW region_commode_mnworkres_dotdensity AS 
+	(SELECT * FROM region_commode_mnworkres_dotdensity_v0);
+GRANT SELECT ON region_commode_mnworkres_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_commode_nonmnworkres_dotdensity;
+CREATE VIEW region_commode_nonmnworkres_dotdensity AS 
+	(SELECT * FROM region_commode_nonmnworkres_dotdensity_v0);
+GRANT SELECT ON region_commode_nonmnworkres_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_commode_nycreswork_dotdensity;
+CREATE VIEW region_commode_nycreswork_dotdensity AS 
+	(SELECT * FROM region_commode_nycreswork_dotdensity_v0);
+GRANT SELECT ON region_commode_nycreswork_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_comtot_nycreswork_dotdensity;
+CREATE VIEW region_comtot_nycreswork_dotdensity AS 
+	(SELECT * FROM region_comtot_nycreswork_dotdensity_v0);
+GRANT SELECT ON region_comtot_nycreswork_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_comtot_nycworkerres_dotdensity;
+CREATE VIEW region_comtot_nycworkerres_dotdensity AS 
+	(SELECT * FROM region_comtot_nycworkerres_dotdensity_v0);
+GRANT SELECT ON region_comtot_nycworkerres_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_county;
+CREATE VIEW region_county AS 
+	(SELECT * FROM region_county_v2);
+GRANT SELECT ON region_county TO publicuser;
+
+DROP VIEW IF EXISTS region_county_meta;
+CREATE VIEW region_county_meta AS 
+	(SELECT * FROM region_county_meta_v2);
+GRANT SELECT ON region_county_meta TO publicuser;
+
+DROP VIEW IF EXISTS region_county_table;
+CREATE VIEW region_county_table AS 
+	(SELECT * FROM region_county_v2_table);
+GRANT SELECT ON region_county_table TO publicuser;
+
+DROP VIEW IF EXISTS region_employment_dotdensity;
+CREATE VIEW region_employment_dotdensity AS 
+	(SELECT * FROM region_employment_dotdensity_v0);
+GRANT SELECT ON region_employment_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_lfpw0016_dotdensity;
+CREATE VIEW region_lfpw0016_dotdensity AS 
+	(SELECT * FROM region_lfpw0016_dotdensity_v1);
+GRANT SELECT ON region_lfpw0016_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_municipality;
+CREATE VIEW region_municipality AS 
+	(SELECT * FROM region_municipality_v1);
+GRANT SELECT ON region_municipality TO publicuser;
+
+DROP VIEW IF EXISTS region_municipality_lf0016_dotdensity;
+CREATE VIEW region_municipality_lf0016_dotdensity AS 
+	(SELECT * FROM region_municipality_lf0016_dotdensity_v0);
+GRANT SELECT ON region_municipality_lf0016_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_municipality_meta;
+CREATE VIEW region_municipality_meta AS 
+	(SELECT * FROM region_municipality_meta_v0);
+GRANT SELECT ON region_municipality_meta TO publicuser;
+
+DROP VIEW IF EXISTS region_municipality_table;
+CREATE VIEW region_municipality_table AS 
+	(SELECT * FROM region_municipality_v1_table);
+GRANT SELECT ON region_municipality_table TO publicuser;
+
+DROP VIEW IF EXISTS region_popa1016_dotdensity;
+CREATE VIEW region_popa1016_dotdensity AS 
+	(SELECT * FROM region_popa1016_dotdensity_v1);
+GRANT SELECT ON region_popa1016_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_rail_lines;
+CREATE VIEW region_rail_lines AS 
+	(SELECT * FROM region_rail_lines_v0);
+GRANT SELECT ON region_rail_lines TO publicuser;
+
+DROP VIEW IF EXISTS region_rail_stops;
+CREATE VIEW region_rail_stops AS 
+	(SELECT * FROM region_rail_stops_v0);
+GRANT SELECT ON region_rail_stops TO publicuser;
+
+DROP VIEW IF EXISTS region_region;
+CREATE VIEW region_region AS 
+	(SELECT * FROM region_region_v2);
+GRANT SELECT ON region_region TO publicuser;
+
+DROP VIEW IF EXISTS region_region_meta;
+CREATE VIEW region_region_meta AS 
+	(SELECT * FROM region_region_meta_v2);
+GRANT SELECT ON region_region_meta TO publicuser;
+
+DROP VIEW IF EXISTS region_region_table;
+CREATE VIEW region_region_table AS 
+	(SELECT * FROM region_region_v2_table);
+GRANT SELECT ON region_region_table TO publicuser;
+
+DROP VIEW IF EXISTS region_subregion;
+CREATE VIEW region_subregion AS 
+	(SELECT * FROM region_subregion_v2);
+GRANT SELECT ON region_subregion TO publicuser;
+
+DROP VIEW IF EXISTS region_subregion_meta;
+CREATE VIEW region_subregion_meta AS 
+	(SELECT * FROM region_subregion_meta_v2);
+GRANT SELECT ON region_subregion_meta TO publicuser;
+
+DROP VIEW IF EXISTS region_subregion_table;
+CREATE VIEW region_subregion_table AS 
+	(SELECT * FROM region_subregion_v2_table);
+GRANT SELECT ON region_subregion_table TO publicuser;
+
+DROP VIEW IF EXISTS region_tenure_dotdensity;
+CREATE VIEW region_tenure_dotdensity AS 
+	(SELECT * FROM region_tenure_dotdensity_v0);
+GRANT SELECT ON region_tenure_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_units_by_structure_dotdensity;
+CREATE VIEW region_units_by_structure_dotdensity AS 
+	(SELECT * FROM region_units_by_structure_dotdensity_v0);
+GRANT SELECT ON region_units_by_structure_dotdensity TO publicuser;
+
+DROP VIEW IF EXISTS region_unittype_dotdensity;
+CREATE VIEW region_unittype_dotdensity AS 
+	(SELECT * FROM region_unittype_dotdensity_v2);
+GRANT SELECT ON region_unittype_dotdensity TO publicuser;
+
 DROP VIEW IF EXISTS scenic_landmarks_lpc;
-CREATE VIEW scenic_landmarks_lpc AS
+CREATE VIEW scenic_landmarks_lpc AS 
 	(SELECT * FROM scenic_landmarks_lpc_v20180501);
 GRANT SELECT ON scenic_landmarks_lpc TO publicuser;
 
-DROP VIEW IF EXISTS citibike_stations;
-CREATE VIEW citibike_stations AS
-	(SELECT * FROM twg_i75aydysqbrqk9zgvg);
-GRANT SELECT ON citibike_stations TO publicuser;
+DROP VIEW IF EXISTS sidewalk_cafes;
+CREATE VIEW sidewalk_cafes AS 
+	(SELECT * FROM sidewalk_cafes_v201902);
+GRANT SELECT ON sidewalk_cafes TO publicuser;
+
+DROP VIEW IF EXISTS special_purpose_districts;
+CREATE VIEW special_purpose_districts AS 
+	(SELECT * FROM special_purpose_districts_v201902);
+GRANT SELECT ON special_purpose_districts TO publicuser;
+
+DROP VIEW IF EXISTS special_purpose_subdistricts;
+CREATE VIEW special_purpose_subdistricts AS 
+	(SELECT * FROM special_purpose_subdistricts_v201902);
+GRANT SELECT ON special_purpose_subdistricts TO publicuser;
+
+DROP VIEW IF EXISTS transitzones;
+CREATE VIEW transitzones AS 
+	(SELECT * FROM transitzones_v201902);
+GRANT SELECT ON transitzones TO publicuser;
+
+DROP VIEW IF EXISTS upland_waterfront_areas;
+CREATE VIEW upland_waterfront_areas AS 
+	(SELECT * FROM upland_waterfront_areas_v200912);
+GRANT SELECT ON upland_waterfront_areas TO publicuser;
+
+DROP VIEW IF EXISTS waterfront_access_plan;
+CREATE VIEW waterfront_access_plan AS 
+	(SELECT * FROM waterfront_access_plan_v201902);
+GRANT SELECT ON waterfront_access_plan TO publicuser;
+
+DROP VIEW IF EXISTS wpaas;
+CREATE VIEW wpaas AS 
+	(SELECT * FROM wpaas_v201811);
+GRANT SELECT ON wpaas TO publicuser;
 
 DROP VIEW IF EXISTS wpaas_accesspoints;
-CREATE VIEW wpaas_accesspoints AS
+CREATE VIEW wpaas_accesspoints AS 
 	(SELECT * FROM wpaas_accesspoints_v201810);
 GRANT SELECT ON wpaas_accesspoints TO publicuser;
 
 DROP VIEW IF EXISTS wpaas_footprints;
-CREATE VIEW wpaas_footprints AS
+CREATE VIEW wpaas_footprints AS 
 	(SELECT * FROM wpaas_footprints_v201810);
 GRANT SELECT ON wpaas_footprints TO publicuser;
 
-DROP VIEW IF EXISTS wpaas;
-CREATE VIEW wpaas AS
-	(SELECT * FROM wpaas_v201811);
-GRANT SELECT ON wpaas TO publicuser;
+DROP VIEW IF EXISTS zoning_districts;
+CREATE VIEW zoning_districts AS 
+	(SELECT * FROM zoning_districts_v201902);
+GRANT SELECT ON zoning_districts TO publicuser;
 
-DROP VIEW IF EXISTS upland_waterfront_areas;
-CREATE VIEW upland_waterfront_areas AS
-	(SELECT * FROM upland_waterfront_areas_v200912);
-GRANT SELECT ON upland_waterfront_areas TO publicuser;
+DROP VIEW IF EXISTS zoning_map_amendments;
+CREATE VIEW zoning_map_amendments AS 
+	(SELECT * FROM zoning_map_amendments_v201902);
+GRANT SELECT ON zoning_map_amendments TO publicuser;


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Closes #123.