### PR TITLE
march metadata updates

### DIFF
--- a/data/sources/pluto.json
+++ b/data/sources/pluto.json
@@ -5,7 +5,7 @@
   "source-layers": [
     {
       "id": "pluto",
-      "sql": "SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors FROM mappluto_18v2"
+      "sql": "SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors FROM mappluto"
     },
     {
       "id": "block-centroids",
@@ -13,10 +13,10 @@
     }
   ],
   "meta": {
-    "description": "MapPLUTO™ v18.2, Bytes of the Big Apple",
+    "description": "MapPLUTO™ 18v2.1, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page#mappluto"
     ],
-    "updated_at": "January 18, 2018"
+    "updated_at": "March 2019"
   }
 }

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -68,11 +68,11 @@
     }
     ],
     "meta": {
-      "description": "Zoning related datasets February 2019, Bytes of the Big Apple",
+      "description": "Zoning related datasets March 2019, Bytes of the Big Apple",
       "url": [
         "https://www1.nyc.gov/site/planning/data-maps/open-data.page#zoning_related"
       ],
-      "data_date": "February 2019",
-      "updated_at": "February 2019"
+      "data_date": "March 2019",
+      "updated_at": "March 2019"
     }
   }

--- a/data/sources/zoning-districts.json
+++ b/data/sources/zoning-districts.json
@@ -8,11 +8,11 @@
     }
   ],
   "meta": {
-    "description": "NYC GIS Zoning Features February, 2019, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features March 2019, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
     ],
-      "data_date": "February, 2019",
-      "updated_at": "February, 2019"
+      "data_date": "March 2019",
+      "updated_at": "March 2019"
   }
 }

--- a/data/sources/zoning-map-amendments.json
+++ b/data/sources/zoning-map-amendments.json
@@ -12,11 +12,11 @@
     }
   ],
   "meta": {
-    "description": "NYC GIS Zoning Features January 2019, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features March 2019, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page"
     ],
-      "data_date": "January, 2019",
-      "updated_at": "February 4, 2019"
+      "data_date": "March 2019",
+      "updated_at": "March 2019"
   }
 }

--- a/scripts/create-carto-aliases.sql
+++ b/scripts/create-carto-aliases.sql
@@ -95,7 +95,7 @@ GRANT SELECT ON coastal_zone_boundary TO publicuser;
 
 DROP VIEW IF EXISTS commercial_overlays;
 CREATE VIEW commercial_overlays AS 
-	(SELECT * FROM commercial_overlays_v201902);
+	(SELECT * FROM commercial_overlays_v201903);
 GRANT SELECT ON commercial_overlays TO publicuser;
 
 DROP VIEW IF EXISTS community_district_profiles;
@@ -110,7 +110,7 @@ GRANT SELECT ON community_districts TO publicuser;
 
 DROP VIEW IF EXISTS e_designations;
 CREATE VIEW e_designations AS 
-	(SELECT * FROM e_designations_v201902);
+	(SELECT * FROM e_designations_v201903);
 GRANT SELECT ON e_designations TO publicuser;
 
 DROP VIEW IF EXISTS facdb;
@@ -160,7 +160,7 @@ GRANT SELECT ON industrial_business_zones TO publicuser;
 
 DROP VIEW IF EXISTS limited_height_districts;
 CREATE VIEW limited_height_districts AS 
-	(SELECT * FROM limited_height_districts_v201902);
+	(SELECT * FROM limited_height_districts_v201903);
 GRANT SELECT ON limited_height_districts TO publicuser;
 
 DROP VIEW IF EXISTS lower_density_growth_management_areas;
@@ -170,12 +170,12 @@ GRANT SELECT ON lower_density_growth_management_areas TO publicuser;
 
 DROP VIEW IF EXISTS mandatory_inclusionary_housing;
 CREATE VIEW mandatory_inclusionary_housing AS 
-	(SELECT * FROM mandatory_inclusionary_housing_v201902);
+	(SELECT * FROM mandatory_inclusionary_housing_v201903);
 GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;
 
 DROP VIEW IF EXISTS mappluto;
 CREATE VIEW mappluto AS 
-	(SELECT * FROM mappluto_18v2);
+	(SELECT * FROM mappluto_18v2_1);
 GRANT SELECT ON mappluto TO publicuser;
 
 DROP VIEW IF EXISTS merged_pfirm_firm_100yr;
@@ -430,12 +430,12 @@ GRANT SELECT ON sidewalk_cafes TO publicuser;
 
 DROP VIEW IF EXISTS special_purpose_districts;
 CREATE VIEW special_purpose_districts AS 
-	(SELECT * FROM special_purpose_districts_v201902);
+	(SELECT * FROM special_purpose_districts_v201903);
 GRANT SELECT ON special_purpose_districts TO publicuser;
 
 DROP VIEW IF EXISTS special_purpose_subdistricts;
 CREATE VIEW special_purpose_subdistricts AS 
-	(SELECT * FROM special_purpose_subdistricts_v201902);
+	(SELECT * FROM special_purpose_subdistricts_v201903);
 GRANT SELECT ON special_purpose_subdistricts TO publicuser;
 
 DROP VIEW IF EXISTS transitzones;
@@ -470,10 +470,10 @@ GRANT SELECT ON wpaas_footprints TO publicuser;
 
 DROP VIEW IF EXISTS zoning_districts;
 CREATE VIEW zoning_districts AS 
-	(SELECT * FROM zoning_districts_v201902);
+	(SELECT * FROM zoning_districts_v201903);
 GRANT SELECT ON zoning_districts TO publicuser;
 
 DROP VIEW IF EXISTS zoning_map_amendments;
 CREATE VIEW zoning_map_amendments AS 
-	(SELECT * FROM zoning_map_amendments_v201902);
+	(SELECT * FROM zoning_map_amendments_v201903);
 GRANT SELECT ON zoning_map_amendments TO publicuser;


### PR DESCRIPTION
This PR updates metadata for end of March data updates. 

Aliases were updated accordingly with this SQL:
```
DROP VIEW IF EXISTS mandatory_inclusionary_housing;
CREATE VIEW mandatory_inclusionary_housing AS 
	(SELECT * FROM mandatory_inclusionary_housing_v201903);
GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;

DROP VIEW IF EXISTS e_designations;
CREATE VIEW e_designations AS 
	(SELECT * FROM e_designations_v201903);
GRANT SELECT ON e_designations TO publicuser;

DROP VIEW IF EXISTS commercial_overlays;
CREATE VIEW commercial_overlays AS 
	(SELECT * FROM commercial_overlays_v201903);
GRANT SELECT ON commercial_overlays TO publicuser;

DROP VIEW IF EXISTS limited_height_districts;
CREATE VIEW limited_height_districts AS 
	(SELECT * FROM limited_height_districts_v201903);
GRANT SELECT ON limited_height_districts TO publicuser;

DROP VIEW IF EXISTS special_purpose_districts;
CREATE VIEW special_purpose_districts AS 
	(SELECT * FROM special_purpose_districts_v201903);
GRANT SELECT ON special_purpose_districts TO publicuser;

DROP VIEW IF EXISTS special_purpose_subdistricts;
CREATE VIEW special_purpose_subdistricts AS 
	(SELECT * FROM special_purpose_subdistricts_v201903);
GRANT SELECT ON special_purpose_subdistricts TO publicuser;

DROP VIEW IF EXISTS zoning_districts;
CREATE VIEW zoning_districts AS 
	(SELECT * FROM zoning_districts_v201903);
GRANT SELECT ON zoning_districts TO publicuser;

DROP VIEW IF EXISTS zoning_map_amendments;
CREATE VIEW zoning_map_amendments AS 
	(SELECT * FROM zoning_map_amendments_v201903);
GRANT SELECT ON zoning_map_amendments TO publicuser;

DROP VIEW IF EXISTS mappluto;
CREATE VIEW mappluto AS 
	(SELECT * FROM mappluto_18v2_1);
GRANT SELECT ON mappluto TO publicuser;

```