### PR TITLE
end of may 2019 data updates

### DIFF
--- a/data/sources/pluto.json
+++ b/data/sources/pluto.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "block-centroids",
-      "sql": "SELECT the_geom_webmercator, block FROM mappluto_block_centroids"
+      "sql": "SELECT the_geom_webmercator, block FROM dtm_block_centroids"
     }
   ],
   "meta": {

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -68,11 +68,11 @@
     }
     ],
     "meta": {
-      "description": "Zoning related datasets April 2019, Bytes of the Big Apple",
+      "description": "Zoning related datasets May 2019, Bytes of the Big Apple",
       "url": [
         "https://www1.nyc.gov/site/planning/data-maps/open-data.page#zoning_related"
       ],
-      "data_date": "April 2019",
-      "updated_at": "April 2019"
+      "data_date": "May 2019",
+      "updated_at": "June 2019"
     }
   }


### PR DESCRIPTION
- Updates metadata for supporting zoning layers
- Updates data source for block centroid labels. EDM has created a new dataset for us called dtm_block_centroids that gets the block centroids from the DTM dataset instead of MapPLUTO.