### PR TITLE
800: add buffer to sources to avoid grid lines showing up on map

### DIFF
--- a/data/sources/pluto.json
+++ b/data/sources/pluto.json
@@ -12,6 +12,9 @@
       "sql": "SELECT the_geom_webmercator, block FROM dtm_block_centroids"
     }
   ],
+  "buffersize": {
+    "mvt": 10
+  },
   "meta": {
     "description": "MapPLUTO™ 18v2.1, Bytes of the Big Apple",
     "url": [

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -67,6 +67,9 @@
       "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name, subarea FROM appendixj_designated_mdistricts"
     }
     ],
+    "buffersize": {
+      "mvt": 10
+    },
     "meta": {
       "description": "Zoning related datasets May 2019, Bytes of the Big Apple",
       "url": [

--- a/data/sources/zoning-districts.json
+++ b/data/sources/zoning-districts.json
@@ -7,6 +7,9 @@
       "sql": "SELECT cartodb_id AS id, * FROM (SELECT the_geom_webmercator, zonedist, CASE WHEN SUBSTRING(zonedist, 3, 1) = '-' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3) ELSE zonedist END as primaryzone, cartodb_id FROM zoning_districts) a"
     }
   ],
+  "buffersize": {
+    "mvt": 10
+  },
   "meta": {
     "description": "NYC GIS Zoning Features April 2019, Bytes of the Big Apple",
     "url": [

--- a/data/sources/zoning-map-amendments.json
+++ b/data/sources/zoning-map-amendments.json
@@ -11,6 +11,9 @@
       "sql": "SELECT the_geom_webmercator, cartodb_id AS id, ulurpno, status, project_na FROM zoning_map_amendments WHERE status = 'Certified'"
     }
   ],
+  "buffersize": {
+    "mvt": 10
+  },
   "meta": {
     "description": "NYC GIS Zoning Features April 2019, Bytes of the Big Apple",
     "url": [


### PR DESCRIPTION
Add buffer to pluto, supporting zoning, zoning amendments, and zoning districts to avoid grid lines showing up on map in zola. 

```
  "buffersize": {
    "mvt": 10
  },
```

Connected to PR #114 (where we first did this for admin boundaries)
Closes #[800](https://github.com/NYCPlanning/labs-zola/issues/800) (issue in zola)


