### PR TITLE
115: add cartodb_id as its own column in addition to cartodb_id AS id

### DIFF
--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -8,11 +8,11 @@
     },
     {
       "id": "special-purpose-districts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, sdlbl, sdname FROM special_purpose_districts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, sdlbl, sdname FROM special_purpose_districts"
     },
     {
       "id": "special-purpose-subdistricts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, splbl, spname, subdist FROM special_purpose_subdistricts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, splbl, spname, subdist FROM special_purpose_subdistricts"
     },
     {
       "id": "mandatory-inclusionary-housing",


### PR DESCRIPTION
We need to include `cartodb_id` AND `cartodb_id AS id` for special purpose districts, because the special purpose districts adapter in zola uses `cartodb_id`
