### PR TITLE
Offline-ify tests by assuming Carto Works; catch error

### DIFF
--- a/utils/carto.js
+++ b/utils/carto.js
@@ -32,7 +32,8 @@ const carto = {
       })
       .then((d) => { // eslint-disable-line
         return type === 'json' ? d.rows : d;
-      });
+      })
+      .catch((d) => { throw d; });
   },
 
   getVectorTileTemplate(sourceConfig) {


### PR DESCRIPTION
This PR mocks the Carto API response using Nock. These tests can be run offline and should work without requiring the API call, eliminating noise in the test environment.

This also adds a "catch" handler to the Carto utility.

Closes #22