### PR TITLE
148 slow responses

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,5 +12,6 @@
     "mocha": true
   },
   "rules": {
+    "func-names": 0
   }
 }

--- a/test/acceptance/routes.layer-group.test.js
+++ b/test/acceptance/routes.layer-group.test.js
@@ -19,8 +19,12 @@ describe('POST /layer-groups', () => {
       .reply(200, cartoResponse);
   });
 
-  afterEach(function teardownNock() {
+  afterEach(function endNock() {
     this.scope.isDone();
+  });
+
+  after(() => {
+    nock.cleanAll();
   });
 
   it('returns a 200 response with json', (done) => {

--- a/test/acceptance/routes.layer-groups.error-handling.test.js
+++ b/test/acceptance/routes.layer-groups.error-handling.test.js
@@ -1,0 +1,35 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const chaiThings = require('chai-things');
+const nock = require('nock');
+const server = require('../../app');
+
+chai.use(chaiThings);
+chai.use(chaiHttp);
+
+describe('POST /layer-groups', () => {
+  after(() => {
+    nock.cleanAll();
+  });
+
+  it('handles an error response from Carto', (done) => {
+    const tempNock = nock('https://planninglabs.carto.com')
+      .post('/api/v1/map')
+      .reply(500, { error: ['timeout'] });
+
+    chai.request(server)
+      .post('/v1/layer-groups')
+      .set('content-type', 'application/json')
+      .send({
+        'layer-groups': [
+          { id: 'zoning-districts', visible: false },
+        ],
+      })
+      .end((err, res) => {
+        res.status.should.equal(500);
+        done();
+      });
+
+    tempNock.isDone();
+  });
+});

--- a/utils/carto.js
+++ b/utils/carto.js
@@ -67,11 +67,11 @@ const carto = {
         },
         body: JSON.stringify(params),
       })
-        .catch(err => reject(err))
         .then(response => response.json())
         .then((json) => {
           resolve(buildTemplate(json, 'mvt'));
-        });
+        })
+        .catch(err => reject(err));
     });
   },
 };


### PR DESCRIPTION
This PR addresses but does not close issue #148 - it handles an error response from Carto, and throws into the logs, so we can understand what is going on.