### PR TITLE
Make json files synchronous, loaded into memory

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,8 @@ app.use(async (ctx, next) => {
   try {
     await next();
   } catch (err) {
+    console.log(err);
+
     ctx.status = err.status || 500;
     ctx.body = { errors: [err] };
     ctx.app.emit('error', err, ctx);

--- a/serializers/layer-groups.js
+++ b/serializers/layer-groups.js
@@ -10,7 +10,9 @@ const { children: sourceAttrs } = sourceSchema.describe();
 
 module.exports = (data, sources = []) => new JSONAPISerializer('layer-groups', {
   transform(record) {
-    const mutatedRecord = record;
+    // generate a new object
+    const mutatedRecord = Object.assign({}, record);
+
     mutatedRecord.sources = sources
       .filter(
         sourceObject => record.layers

--- a/utils/local-resources-utilities/-load-json.js
+++ b/utils/local-resources-utilities/-load-json.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const { sync: loadJsonFile } = require('load-json-file');
+const fs = require('fs');
+
+const availableResources = fs.readdirSync(
+  path.resolve(__dirname, '../../data'),
+);
+
+const fileNames = availableResources.reduce((resourceCollections, resourceName) => {
+  const resourceCollectionsMut = resourceCollections;
+
+  const filesHash = fs.readdirSync(
+    path.resolve(__dirname, `../../data/${resourceName}`),
+  )
+    .reduce((resourceValues, fileName) => {
+      const resourceValuesMut = resourceValues;
+      const identifier = fileName.split('.')[0];
+
+      // generate a new object for this
+      resourceValuesMut[identifier] = Object.assign(
+        {},
+        loadJsonFile(
+          path.resolve(__dirname, `../../data/${resourceName}/${fileName}`),
+        ),
+      );
+
+      return resourceValues;
+    }, {});
+
+  resourceCollectionsMut[resourceName] = filesHash;
+
+  return resourceCollections;
+}, {});
+
+// exports a hash of resources keyed by resource name and identifier
+module.exports = fileNames;

--- a/utils/local-resources-utilities/find-all.js
+++ b/utils/local-resources-utilities/find-all.js
@@ -1,17 +1,3 @@
-const path = require('path');
-const loadJsonFile = require('load-json-file');
-const fs = require('fs');
+const fileNames = require('./-load-json');
 
-module.exports = (resourceName) => {
-  const fileNames = fs.readdirSync(
-    path.resolve(__dirname, `../../data/${resourceName}`),
-  );
-
-  return Promise.all(
-    fileNames.map(
-      fileName => loadJsonFile(
-        path.resolve(__dirname, `../../data/${resourceName}/${fileName}`),
-      ),
-    ),
-  );
-};
+module.exports = resourceName => Object.values(fileNames[resourceName]);

--- a/utils/local-resources-utilities/find.js
+++ b/utils/local-resources-utilities/find.js
@@ -1,7 +1,4 @@
 // findOne(type, id)
-const path = require('path');
-const loadJsonFile = require('load-json-file');
+const fileNames = require('./-load-json');
 
-module.exports = (resourceName, identifier) => loadJsonFile(
-  path.resolve(__dirname, `../../data/${resourceName}/${identifier}.json`),
-);
+module.exports = (resourceName, identifier) => fileNames[resourceName][identifier];

--- a/utils/local-resources-utilities/where.js
+++ b/utils/local-resources-utilities/where.js
@@ -1,14 +1,11 @@
 // findOne(type, id)
-const path = require('path');
-const loadJsonFile = require('load-json-file');
+const fileNames = require('./-load-json');
 
 module.exports = (resourceName, { id: ids }) => {
   if (ids) {
     return Promise.all(
       ids.map(
-        identifier => loadJsonFile(
-          path.resolve(__dirname, `../../data/${resourceName}/${identifier}.json`),
-        ),
+        identifier => fileNames[resourceName][identifier],
       ),
     );
   }


### PR DESCRIPTION
Addresses #155 by forcing the full database to be loaded in-memory when the app boots up. It's unclear whether this will actually improve anything because anecdotally I can say with confidence that the performance bottleneck comes from the large # of Carto maps API calls. 

Still, we should keep drilling down to see how we can make the Carto query more efficient.

