### PR TITLE
Use one tile URL; group layers into URLs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "mocha": true
   },
   "rules": {
-    "func-names": 0
+    "func-names": 0,
+    "camelcase": 0,
   }
 }

--- a/app.js
+++ b/app.js
@@ -31,6 +31,8 @@ app.use(async (ctx, next) => {
   try {
     await next();
   } catch (err) {
+    console.log(err);
+
     ctx.status = err.status || 500;
     ctx.body = { errors: [err] };
     ctx.app.emit('error', err, ctx);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "postinstall": "npm run create-sprite-svgs",
     "start": "node app.js",
-    "devstart": "nodemon app.js",
+    "devstart": "nodemon --inspect app.js",
     "test": "PORT=3001 NODE_ENV=test node ./node_modules/mocha/bin/mocha ./test/**/*.js --exit",
     "watch-tests": "nodemon --exec 'npm run test || true'",
     "create-sprite-svgs": "node ./assets/sprite/create-sprite-svgs.js",

--- a/test/unit/utils.structure-carto-source.test.js
+++ b/test/unit/utils.structure-carto-source.test.js
@@ -17,12 +17,12 @@ describe('structure-carto-source util', () => {
 
     try {
       const source = await find('sources', 'pluto');
-      const cartoSource = await getSource(source);
+      const cartoSource = await getSource([source]);
 
-      should.exist(cartoSource.pluto);
-      should.exist(cartoSource.pluto.type);
-      should.exist(cartoSource.pluto.tiles);
-      cartoSource.pluto.type.should.equal('vector');
+      should.exist(cartoSource[0].id);
+      should.exist(cartoSource[0].type);
+      should.exist(cartoSource[0].tiles);
+      cartoSource[0].type.should.equal('vector');
     } catch (e) {
       throw new Error(e);
     }

--- a/utils/build-mapbox-style.js
+++ b/utils/build-mapbox-style.js
@@ -1,6 +1,7 @@
 const unique = require('array-unique');
 const { where } = require('./local-resources-utilities');
 const structureCartoSource = require('./structure-carto-source');
+const structureRegularSources = require('./structure-regular-source');
 const baseStyle = require('../data/base/style.json');
 
 const HOST = process.env.HOST || 'http://localhost:3000';
@@ -38,6 +39,7 @@ module.exports = async (layerGroups) => {
   // TODO use the order of the layers specified in the config to determine the correct order
   // TODO set visibility for each layer
   // TODO insert before labels
+  // WHAT WAS THIS?!
   // baseStyle.layers = [...baseStyle.layers, ...layers];
 
   // de-dupe source ids, many layers may require the same source
@@ -46,9 +48,14 @@ module.exports = async (layerGroups) => {
 
   // get sources for each id
   const sources = await where('sources', { id: sourceIds });
+
+  // these must happen in the aggregate in order to round up everything
+  // into a single request
+  const sourcesWithCarto = await structureCartoSource(sources);
+
   const structuredSources = await Promise.all(
-    sources.map(
-      source => structureCartoSource(source),
+    sourcesWithCarto.map(
+      source => structureRegularSources(source),
     ),
   );
 

--- a/utils/carto.js
+++ b/utils/carto.js
@@ -18,6 +18,7 @@ const buildSqlUrl = function(cleanedQuery, type = 'json') { // eslint-disable-li
 };
 
 const carto = {
+  cartoDomain,
   SQL(query, type = 'json') {
     const cleanedQuery = query.replace('\n', '');
     const url = buildSqlUrl(cleanedQuery, type);
@@ -36,15 +37,12 @@ const carto = {
   },
 
   getVectorTileTemplate(sourceConfig) {
-    const CartoCSS = '#layer { polygon-fill: #FFF; }';
     const layers = sourceConfig['source-layers'].map((sourceLayer) => {
       const { id, sql } = sourceLayer;
       return {
         id,
         type: 'mapnik',
         options: {
-          cartocss_version: '2.3.0',
-          cartocss: CartoCSS,
           sql,
         },
       };
@@ -72,7 +70,6 @@ const carto = {
 
         return response.json();
       })
-      .then(json => buildTemplate(json, 'mvt'))
       .catch(response => response.json().then((resolved) => {
         throw new Error(resolved.error);
       }));

--- a/utils/structure-regular-source.js
+++ b/utils/structure-regular-source.js
@@ -1,0 +1,10 @@
+module.exports = async (sourceConfig) => {
+  const { id } = sourceConfig;
+
+  const source = {};
+  source[id] = {
+    ...sourceConfig,
+  };
+
+  return source;
+};


### PR DESCRIPTION
Addresses #148 and #150 by squashing the number of requests to Carto one, and grouping specific layers of sources into a single URL template for each source definition.

Anecdotally this improves load times and reliability dramatically but should be tested on canary first.