### PR TITLE
nov 2019 data updates

### DIFF
--- a/data/sources/landmark-historic.json
+++ b/data/sources/landmark-historic.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "historic-districts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, area_name FROM historic_districts_lpc WHERE status_of = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, area_name FROM historic_districts_lpc WHERE status_of_ = 'DESIGNATED'"
     },
     {
       "id": "landmarks",

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -71,11 +71,11 @@
       "mvt": 10
     },
     "meta": {
-      "description": "Zoning related datasets Oct 2019, Bytes of the Big Apple",
+      "description": "Zoning related datasets Nov 2019, Bytes of the Big Apple",
       "url": [
         "https://www1.nyc.gov/site/planning/data-maps/open-data.page#zoning_related"
       ],
-      "data_date": "Oct 2019",
-      "updated_at": "Oct 2019"
+      "data_date": "Nov 2019",
+      "updated_at": "Nov 2019"
     }
   }

--- a/data/sources/zoning-districts.json
+++ b/data/sources/zoning-districts.json
@@ -11,11 +11,11 @@
     "mvt": 10
   },
   "meta": {
-    "description": "NYC GIS Zoning Features Oct 2019, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features Nov 2019, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
     ],
-      "data_date": "Oct 2019",
-      "updated_at": "Oct 2019"
+      "data_date": "Nov 2019",
+      "updated_at": "Nov 2019"
   }
 }

--- a/data/sources/zoning-map-amendments.json
+++ b/data/sources/zoning-map-amendments.json
@@ -15,11 +15,11 @@
     "mvt": 10
   },
   "meta": {
-    "description": "NYC GIS Zoning Features Oct 2019, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features Nov 2019, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page"
     ],
-      "data_date": "Oct 2019",
-      "updated_at": "Oct 2019"
+      "data_date": "Nov 2019",
+      "updated_at": "Nov 2019"
   }
 }

--- a/scripts/create-carto-aliases.sql
+++ b/scripts/create-carto-aliases.sql
@@ -100,7 +100,7 @@ GRANT SELECT ON coastal_zone_boundary TO publicuser;
 
 DROP VIEW IF EXISTS commercial_overlays;
 CREATE VIEW commercial_overlays AS
-	(SELECT * FROM commercial_overlays_v201910);
+	(SELECT * FROM commercial_overlays_v201911);
 GRANT SELECT ON commercial_overlays TO publicuser;
 
 DROP VIEW IF EXISTS community_district_profiles;
@@ -115,12 +115,12 @@ GRANT SELECT ON community_districts TO publicuser;
 
 DROP VIEW IF EXISTS dtm_block_centroids;
 CREATE VIEW dtm_block_centroids AS
-	(SELECT * FROM dtm_block_centroids_v20191101);
+	(SELECT * FROM dtm_block_centroids_v20191206);
 GRANT SELECT ON dtm_block_centroids TO publicuser;
 
 DROP VIEW IF EXISTS e_designations;
 CREATE VIEW e_designations AS
-	(SELECT * FROM e_designations_v201910);
+	(SELECT * FROM e_designations_v201911);
 GRANT SELECT ON e_designations TO publicuser;
 
 DROP VIEW IF EXISTS facdb;
@@ -145,7 +145,7 @@ GRANT SELECT ON fresh_zones TO publicuser;
 
 DROP VIEW IF EXISTS historic_districts_lpc;
 CREATE VIEW historic_districts_lpc AS
-	(SELECT * FROM historic_districts_lpc_v20180501);
+	(SELECT * FROM historic_districts_lpc_v20190628);
 GRANT SELECT ON historic_districts_lpc TO publicuser;
 
 DROP VIEW IF EXISTS humanboatlaunch;
@@ -160,7 +160,7 @@ GRANT SELECT ON inclusionary_housing TO publicuser;
 
 DROP VIEW IF EXISTS individual_landmarks_lpc;
 CREATE VIEW individual_landmarks_lpc AS
-	(SELECT * FROM individual_landmarks_lpc_v20180501);
+	(SELECT * FROM individual_landmarks_lpc_v20190705);
 GRANT SELECT ON individual_landmarks_lpc TO publicuser;
 
 DROP VIEW IF EXISTS industrial_business_zones;
@@ -170,7 +170,7 @@ GRANT SELECT ON industrial_business_zones TO publicuser;
 
 DROP VIEW IF EXISTS limited_height_districts;
 CREATE VIEW limited_height_districts AS
-	(SELECT * FROM limited_height_districts_v201910);
+	(SELECT * FROM limited_height_districts_v201911);
 GRANT SELECT ON limited_height_districts TO publicuser;
 
 DROP VIEW IF EXISTS lower_density_growth_management_areas;
@@ -180,7 +180,7 @@ GRANT SELECT ON lower_density_growth_management_areas TO publicuser;
 
 DROP VIEW IF EXISTS mandatory_inclusionary_housing;
 CREATE VIEW mandatory_inclusionary_housing AS
-	(SELECT * FROM mandatory_inclusionary_housing_v201910);
+	(SELECT * FROM mandatory_inclusionary_housing_v201911);
 GRANT SELECT ON mandatory_inclusionary_housing TO publicuser;
 
 CREATE INDEX idx_mappluto_19v2_bbl ON planninglabs.mappluto_19v2 (bbl);
@@ -266,22 +266,22 @@ GRANT SELECT ON publiclyownedwaterfront TO publicuser;
 
 DROP VIEW IF EXISTS scenic_landmarks_lpc;
 CREATE VIEW scenic_landmarks_lpc AS
-	(SELECT * FROM scenic_landmarks_lpc_v20180501);
+	(SELECT * FROM scenic_landmarks_lpc_v20181019);
 GRANT SELECT ON scenic_landmarks_lpc TO publicuser;
 
 DROP VIEW IF EXISTS sidewalk_cafes;
 CREATE VIEW sidewalk_cafes AS
-	(SELECT * FROM sidewalk_cafes_v201909);
+	(SELECT * FROM sidewalk_cafes_v201911);
 GRANT SELECT ON sidewalk_cafes TO publicuser;
 
 DROP VIEW IF EXISTS special_purpose_districts;
 CREATE VIEW special_purpose_districts AS
-	(SELECT * FROM special_purpose_districts_v201910);
+	(SELECT * FROM special_purpose_districts_v201911);
 GRANT SELECT ON special_purpose_districts TO publicuser;
 
 DROP VIEW IF EXISTS special_purpose_subdistricts;
 CREATE VIEW special_purpose_subdistricts AS
-	(SELECT * FROM special_purpose_subdistricts_v201910);
+	(SELECT * FROM special_purpose_subdistricts_v201911);
 GRANT SELECT ON special_purpose_subdistricts TO publicuser;
 
 DROP VIEW IF EXISTS transitzones;
@@ -316,12 +316,12 @@ GRANT SELECT ON wpaas_footprints TO publicuser;
 
 DROP VIEW IF EXISTS zoning_districts;
 CREATE VIEW zoning_districts AS
-	(SELECT * FROM zoning_districts_v201910);
+	(SELECT * FROM zoning_districts_v201911);
 GRANT SELECT ON zoning_districts TO publicuser;
 
 DROP VIEW IF EXISTS zoning_map_amendments;
 CREATE VIEW zoning_map_amendments AS
-	(SELECT * FROM zoning_map_amendments_v201910);
+	(SELECT * FROM zoning_map_amendments_v201911);
 GRANT SELECT ON zoning_map_amendments TO publicuser;
 
 DROP VIEW IF EXISTS region_censustract;


### PR DESCRIPTION
- Updates metadata and SQL documentation for views of latest data
- Updates query for historic landmarks, since the name of a column changed slightly

All the of the views, except for the historic_districts_lpc one, have been updated on Carto already.

Once this is merged in master, we need to immediately update the view for historic landmarks. Updating it now, without the corresponding SQL changes in the data source file, breaks the ZoLa app.
```
DROP VIEW IF EXISTS historic_districts_lpc;
CREATE VIEW historic_districts_lpc AS
	(SELECT * FROM historic_districts_lpc_v20190628);
GRANT SELECT ON historic_districts_lpc TO publicuser;
```