### PR TITLE
add 2018 aerials from DoITT

### DIFF
--- a/data/layer-groups/aerials.json
+++ b/data/layer-groups/aerials.json
@@ -8,11 +8,23 @@
   "layers": [
     {
       "before": "boundary_state",
+      "displayName": "2018",
+      "style": {
+        "id": "aerials-2018",
+        "layout": {
+          "visibility": "visible"
+        },
+        "source": "aerials-2018",
+        "type": "raster"
+      }
+    },
+    {
+      "before": "boundary_state",
       "displayName": "2016",
       "style": {
         "id": "aerials-2016",
         "layout": {
-          "visibility": "visible"
+          "visibility": "none"
         },
         "source": "aerials-2016",
         "type": "raster"

--- a/data/sources/aerials-2018.json
+++ b/data/sources/aerials-2018.json
@@ -1,0 +1,15 @@
+{
+  "id": "aerials-2018",
+  "type": "raster",
+  "tiles": [
+    "https://maps.nyc.gov/xyz/1.0.0/photo/2018/{z}/{x}/{y}.png8"
+  ],
+  "tileSize": 256,
+  "meta": {
+    "description": "NYC DoITT GIS Aerial Photography Tile Layers (TMS)",
+    "url": [
+      "https://maps.nyc.gov/tiles/"
+    ],
+    "updated_at": "n/a"
+  }
+}


### PR DESCRIPTION
Corresponding front-end work is needed. Addresses: https://github.com/NYCPlanning/labs-zola/issues/961

I think the code changes in this PR (new source file and addition to layer group file) are all that are needed to provide the 2018 aerials.