### PR TITLE
update citymap w/ new data schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /assets/sprite/svg/*
 
 .DS_Store
+newrelic_agent.log

--- a/data/layer-groups/citymap.json
+++ b/data/layer-groups/citymap.json
@@ -185,7 +185,7 @@
           [
             "==",
             "feat_type",
-            "Record"
+            "Record_St"
           ]
         ]
       }
@@ -364,7 +364,7 @@
           [
             "==",
             "feat_type",
-            "Record"
+            "Record_St"
           ]
         ],
         "paint": {

--- a/data/layer-groups/citymap.json
+++ b/data/layer-groups/citymap.json
@@ -137,15 +137,15 @@
           "all",
           [
             "==",
-            "type",
-            "Mapped Street"
+            "feat_type",
+            "Mapped_St"
           ]
         ]
       }
     },
     {
       "tooltipable": true,
-      "tooltipTemplate": "{{{type}}}",
+      "tooltipTemplate": "{{{feat_type}}}",
       "style": {
         "id": "citymap-streets-tooltip-line",
         "type": "line",
@@ -174,18 +174,18 @@
           "any",
           [
             "==",
-            "type",
-            "Mapped Street"
+            "feat_type",
+            "Mapped_St"
           ],
           [
             "==",
-            "type",
-            "Street not mapped"
+            "feat_type",
+            "Unmapped_St"
           ],
           [
             "==",
-            "type",
-            "Record Street"
+            "feat_type",
+            "Record"
           ]
         ]
       }
@@ -200,8 +200,8 @@
           "all",
           [
             "==",
-            "type",
-            "street_treatment"
+            "feat_type",
+            "Street_treatment"
           ]
         ],
         "paint": {
@@ -246,8 +246,8 @@
           "all",
           [
             "==",
-            "type",
-            "Underpass or Tunnel"
+            "feat_type",
+            "Underpass_or_tunnel"
           ]
         ],
         "paint": {
@@ -310,8 +310,8 @@
           "all",
           [
             "==",
-            "type",
-            "Street not mapped"
+            "feat_type",
+            "Unmapped_St"
           ]
         ],
         "paint": {
@@ -363,8 +363,8 @@
           "all",
           [
             "==",
-            "type",
-            "Record Street"
+            "feat_type",
+            "Record"
           ]
         ],
         "paint": {
@@ -453,8 +453,8 @@
           "all",
           [
             "==",
-            "type",
-            "Underpass or Tunnel"
+            "feat_type",
+            "Underpass_or_tunnel"
           ]
         ],
         "paint": {

--- a/data/sources/digital-citymap.json
+++ b/data/sources/digital-citymap.json
@@ -24,7 +24,7 @@
     },
     {
       "id": "citymap",
-      "sql": "SELECT the_geom_webmercator, feat_type, borough FROM dcm_v202005 WHERE feat_type NOT IN ('Pierhead_line', 'Bulkhead_line', 'Rail')"
+      "sql": "SELECT the_geom_webmercator, (CASE WHEN record_st = 'Yes' THEN 'Record_St' ELSE feat_type END) as feat_type, record_st, borough FROM dcm_v202005 WHERE feat_type NOT IN ('Pierhead_line', 'Bulkhead_line', 'Rail')"
     },
     {
       "id": "name-changes-points",


### PR DESCRIPTION
This PR fixes the `citymap` layer group's style filters to work with the new data schema. 