### PR TITLE
865 Target env-specific Carto tables,  round 1

### DIFF
--- a/data/sources/digital-citymap.json
+++ b/data/sources/digital-citymap.json
@@ -4,43 +4,43 @@
   "source-layers": [
     {
       "id": "bulkhead-lines",
-      "sql": "SELECT the_geom_webmercator, jurisdicti FROM dcm WHERE feat_type = 'Bulkhead_line'"
+      "sql": "SELECT the_geom_webmercator, jurisdicti FROM dcm_{{ENV}} WHERE feat_type = 'Bulkhead_line'"
     },
     {
       "id": "arterials",
-      "sql": "SELECT the_geom_webmercator, route_type FROM dcm_arterialsmajorstreets"
+      "sql": "SELECT the_geom_webmercator, route_type FROM dcm_arterialsmajorstreets_{{ENV}}"
     },
     {
       "id": "pierhead-lines",
-      "sql": "SELECT the_geom_webmercator, jurisdicti FROM dcm WHERE feat_type = 'Pierhead_line'"
+      "sql": "SELECT the_geom_webmercator, jurisdicti FROM dcm_{{ENV}} WHERE feat_type = 'Pierhead_line'"
     },
     {
       "id": "amendments",
-      "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id AS id, altmappdf, extract(epoch from effect_dt) as effective, status FROM dcm_citymapalterations ORDER BY area DESC"
+      "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id AS id, altmappdf, extract(epoch from effect_dt) as effective, status FROM dcm_citymapalterations_{{ENV}} ORDER BY area DESC"
     },
     {
       "id": "street-centerlines",
-      "sql": "SELECT the_geom_webmercator, street_nm AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadwaytyp, feat_statu FROM dcm_streetcenterline"
+      "sql": "SELECT the_geom_webmercator, street_nm AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadwaytyp, feat_statu FROM dcm_streetcenterline_{{ENV}}"
     },
     {
       "id": "citymap",
-      "sql": "SELECT the_geom_webmercator, (CASE WHEN record_st = 'Yes' THEN 'Record_St' ELSE feat_type END) as feat_type, record_st, borough FROM dcm WHERE feat_type NOT IN ('Pierhead_line', 'Bulkhead_line', 'Rail')"
+      "sql": "SELECT the_geom_webmercator, (CASE WHEN record_st = 'Yes' THEN 'Record_St' ELSE feat_type END) as feat_type, record_st, borough FROM dcm_{{ENV}} WHERE feat_type NOT IN ('Pierhead_line', 'Bulkhead_line', 'Rail')"
     },
     {
       "id": "name-changes-points",
-      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_points"
+      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_points_{{ENV}}"
     },
     {
       "id": "name-changes-lines",
-      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_lines"
+      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_lines_{{ENV}}"
     },
     {
       "id": "name-changes-areas",
-      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_areas"
+      "sql": "SELECT the_geom_webmercator, intro_num, intro_year, lleffectdt, CASE WHEN honor_name = 'none' THEN officialnm ELSE honor_name END FROM dcm_streetnamechanges_areas_{{ENV}}"
     },
     {
       "id": "rail-lines",
-      "sql": "SELECT the_geom_webmercator, '' AS street FROM dcm WHERE feat_type = 'Rail'"
+      "sql": "SELECT the_geom_webmercator, '' AS street FROM dcm_{{ENV}} WHERE feat_type = 'Rail'"
     }
   ],
   "meta": {

--- a/data/sources/landmark-historic.json
+++ b/data/sources/landmark-historic.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "historic-districts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, area_name FROM historic_districts_lpc WHERE status_of_ = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, area_name FROM historic_districts_lpc_{{ENV}} WHERE status_of_ = 'DESIGNATED'"
     },
     {
       "id": "landmarks",
@@ -12,7 +12,7 @@
     },
     {
       "id": "scenic-landmarks",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, scen_lm_na FROM scenic_landmarks_lpc WHERE last_actio = 'DESIGNATED'"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, scen_lm_na FROM scenic_landmarks_lpc_{{ENV}} WHERE last_actio = 'DESIGNATED'"
     }
   ],
   "minzoom": 0,

--- a/data/sources/pluto.json
+++ b/data/sources/pluto.json
@@ -5,11 +5,11 @@
   "source-layers": [
     {
       "id": "pluto",
-      "sql": "SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors, notes FROM mappluto"
+      "sql": "SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors, notes FROM mappluto_{{ENV}}"
     },
     {
       "id": "block-centroids",
-      "sql": "SELECT the_geom_webmercator, block FROM dtm_block_centroids"
+      "sql": "SELECT the_geom_webmercator, block FROM dtm_block_centroids_{{ENV}}"
     }
   ],
   "buffersize": {

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -4,19 +4,19 @@
   "source-layers": [
     {
       "id": "commercial-overlays",
-      "sql": "SELECT cartodb_id AS id, * FROM commercial_overlays"
+      "sql": "SELECT cartodb_id AS id, * FROM commercial_overlays_{{ENV}}"
     },
     {
       "id": "special-purpose-districts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, sdlbl, sdname FROM special_purpose_districts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, sdlbl, sdname FROM special_purpose_districts_{{ENV}}"
     },
     {
       "id": "special-purpose-subdistricts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, splbl, spname, subdist FROM special_purpose_subdistricts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, cartodb_id, splbl, spname, subdist FROM special_purpose_subdistricts_{{ENV}}"
     },
     {
       "id": "mandatory-inclusionary-housing",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, projectnam, mih_option FROM mandatory_inclusionary_housing"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, projectnam, mih_option FROM mandatory_inclusionary_housing_{{ENV}}"
     },
     {
       "id": "inclusionary-housing",
@@ -24,15 +24,15 @@
     },
     {
       "id": "transit-zones",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id FROM transitzones"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id FROM transitzones_{{ENV}}"
     },
     {
       "id": "fresh",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name FROM fresh_zones"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name FROM fresh_zones_{{ENV}}"
     },
     {
       "id": "sidewalk-cafes",
-      "sql": "SELECT the_geom_webmercator, cafetype FROM sidewalk_cafes"
+      "sql": "SELECT the_geom_webmercator, cafetype FROM sidewalk_cafes_{{ENV}}"
     },
     {
       "id": "low-density-growth-mgmt-areas",
@@ -40,15 +40,15 @@
     },
     {
       "id": "coastal-zone-boundary",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id FROM coastal_zone_boundary"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id FROM coastal_zone_boundary_{{ENV}}"
     },
     {
       "id": "waterfront-access-plan",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name FROM waterfront_access_plan"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name FROM waterfront_access_plan_{{ENV}}"
     },
     {
       "id": "limited-height-districts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, lhlbl, lhname FROM limited_height_districts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, lhlbl, lhname FROM limited_height_districts_{{ENV}}"
     },
     {
       "id": "business-improvement-districts",
@@ -64,7 +64,7 @@
     },
     {
       "id": "appendixj-designated-mdistricts",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name, subarea FROM appendixj_designated_mdistricts"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, name, subarea FROM appendixj_designated_mdistricts_{{ENV}}"
     }
     ],
     "buffersize": {

--- a/data/sources/zoning-districts.json
+++ b/data/sources/zoning-districts.json
@@ -4,7 +4,7 @@
   "source-layers": [
     {
       "id": "zoning-districts",
-      "sql": "SELECT cartodb_id AS id, * FROM (SELECT the_geom_webmercator, zonedist, CASE WHEN SUBSTRING(zonedist, 3, 1) = '-' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3) ELSE zonedist END as primaryzone, cartodb_id FROM zoning_districts) a"
+      "sql": "SELECT cartodb_id AS id, * FROM (SELECT the_geom_webmercator, zonedist, CASE WHEN SUBSTRING(zonedist, 3, 1) = '-' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3) ELSE zonedist END as primaryzone, cartodb_id FROM zoning_districts_{{ENV}}) a"
     }
   ],
   "buffersize": {

--- a/data/sources/zoning-map-amendments.json
+++ b/data/sources/zoning-map-amendments.json
@@ -4,11 +4,11 @@
   "source-layers": [
     {
       "id": "zoning-map-amendments",
-      "sql": "SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, 'MM/DD/YYYY') as effectiveformatted, extract(epoch from effective) * 1000 as effective_epoch, cartodb_id AS id, ulurpno, status, project_na FROM planninglabs.zoning_map_amendments WHERE status = 'Adopted') a"
+      "sql": "SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, 'MM/DD/YYYY') as effectiveformatted, extract(epoch from effective) * 1000 as effective_epoch, cartodb_id AS id, ulurpno, status, project_na FROM planninglabs.zoning_map_amendments_{{ENV}} WHERE status = 'Adopted') a"
     },
     {
       "id": "zoning-map-amendments-pending",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, ulurpno, status, project_na FROM zoning_map_amendments WHERE status = 'Certified'"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, ulurpno, status, project_na FROM zoning_map_amendments_{{ENV}} WHERE status = 'Certified'"
     }
   ],
   "buffersize": {

--- a/utils/carto.js
+++ b/utils/carto.js
@@ -1,5 +1,7 @@
 const fetch = require('node-fetch');
 
+const ENV = process.env.NODE_ENV;
+
 const cartoUsername = 'planninglabs';
 const cartoDomain = `${cartoUsername}.carto.com`;
 
@@ -39,11 +41,15 @@ const carto = {
   getVectorTileTemplate(sourceConfig) {
     const layers = sourceConfig['source-layers'].map((sourceLayer) => {
       const { id, sql } = sourceLayer;
+
+      // Switch between staging and production Carto tables
+      const envSpecificSql = sql.replace('{{ENV}}', ENV === 'production' ? 'production' : 'staging');
+
       return {
         id,
         type: 'mapnik',
         options: {
-          sql,
+          sql: envSpecificSql,
         },
       };
     });


### PR DESCRIPTION
## Summary
This PR updates Layers API to work with the new EDM Data Pipeline. EDM is now uploading tables to carto with _production and _staging suffixes, and Layers API needs to target these tables. Previously Layers API targeted views named without those suffixes. 

This PR only makes updates for tables Adrien reported is ready as of 2/17. Others are yet to be updated* 

## Technical Summary
Within the `data/sources` files, this PR  parameterizes table names within sql statements using {{ENV}} placeholder. {{ENV}} will be replayed with either '_production' or '_staging' depending on the Node env. 

## Tickets
Fixes [AB#865](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/865)

## Other info
*Other layers not yet updated:
aerials
subway lines, mta lines, (sources/transportations.json)
supporting-zoning
supporting-zoning.json:
inclusionary_housing
lower_density_growth_management_areas
business_improvement_districts
e_designations
industrial_business_zones
preliminary-flood-insurance:
floodplain_pfirm2015
planimetrics.json:
sidewalks_v201809
transportation_structures_v201809
paws.json
wam_wpaas
wam_publiclyownedwaterfront
wam_wpaas_footprints
wam_wpaas_accesspoints
floodplains.json / effective-flood-insurance-rate-2007
floodplain_pfirm2015
floodplain_firm2007

ferries.json
nyc_ferry_routes
nyc_ferry_landings
citibike-stations.json
citibike_stations

census-geoms.json
nyc_census_tracts
nyc_census_blocks

boat-launches.json
wam_hpb_launches

admin-boundaries.json
nta_boundaries
boro_boundaries
nyc_council_districts
ny_senate_districts
ny_assembly_districts
nyc_pumas
bk_qn_mh_boundary