### PR TITLE
4282 update sql queries with new 2020 geos

### DIFF
--- a/data/layer-groups/factfinder--census-blocks.json
+++ b/data/layer-groups/factfinder--census-blocks.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--census-blocks-fill",
         "type": "fill",
-        "source": "census-geoms",
+        "source": "census-geoms-2020",
         "source-layer": "census-geoms-blocks",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "census-blocks-line",
         "type": "line",
-        "source": "census-geoms",
+        "source": "census-geoms-2020",
         "source-layer": "census-geoms-blocks",
         "paint": {
           "line-color": "#444",
@@ -44,10 +44,10 @@
     },
     {
       "style": {
-        "id": "census-prominent-tracts-line",
+        "id": "census-prominent-blocks-line",
         "type": "line",
-        "source": "census-geoms",
-        "source-layer": "census-geoms-tracts",
+        "source": "census-geoms-2020",
+        "source-layer": "census-geoms-blocks",
         "paint": {
           "line-color": "#444",
           "line-opacity": 0.3,
@@ -74,7 +74,7 @@
       "style": {
         "id": "census-blocks-label",
         "type": "symbol",
-        "source": "census-geoms",
+        "source": "census-geoms-2020",
         "source-layer": "census-geoms-blocks",
         "minzoom": 11,
         "paint": {
@@ -96,7 +96,7 @@
           }
         },
         "layout": {
-          "text-field": "{cb2010}",
+          "text-field": "{cb2020}",
           "text-font": [
             "Open Sans Semibold",
             "Arial Unicode MS Bold"
@@ -118,10 +118,10 @@
     },
     {
       "style": {
-        "id": "census-tracts-label-for-blocks",
+        "id": "census-blocks-label-for-blocks",
         "type": "symbol",
-        "source": "census-geoms",
-        "source-layer": "census-geoms-tracts",
+        "source": "census-geoms-2020",
+        "source-layer": "census-geoms-blocks",
         "minzoom": 11,
         "paint": {
           "text-color": "#626262",

--- a/data/layer-groups/factfinder--districts.json
+++ b/data/layer-groups/factfinder--districts.json
@@ -6,7 +6,7 @@
         "id": "factfinder--districts-fill",
         "type": "fill",
         "source": "admin-boundaries",
-        "source-layer": "dcp_community_districts",
+        "source-layer": "factfinder_dcp_community_districts",
         "paint": {
           "fill-opacity": 0.01
         }
@@ -19,7 +19,7 @@
         "id": "districts-line",
         "type": "line",
         "source": "admin-boundaries",
-        "source-layer": "dcp_community_districts",
+        "source-layer": "factfinder_dcp_community_districts",
         "paint": {
           "line-color": "#444",
           "line-opacity": 0.5,
@@ -47,7 +47,7 @@
         "id": "districts-label",
         "type": "symbol",
         "source": "admin-boundaries",
-        "source-layer": "dcp_community_districts",
+        "source-layer": "factfinder_dcp_community_districts",
         "minzoom": 11,
         "paint": {
           "text-color": "#626262",
@@ -68,7 +68,7 @@
           }
         },
         "layout": {
-          "text-field": "{boro_district}",
+          "text-field": "{geoid}",
           "text-font": [
             "Open Sans Semibold",
             "Arial Unicode MS Bold"

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -48,6 +48,11 @@
       "dataPipeline": false
     },
     {
+      "id": "factfinder_dcp_community_districts",
+      "sql": "SELECT the_geom_webmercator, borocd, cd_short_title, borocd as geoid FROM cd_boundaries_v0_dh",
+      "dataPipeline": true
+    },
+    {
       "id": "cities",
       "sql": "SELECT the_geom_webmercator, id FROM nyc2020_sw_unofficial",
       "dataPipeline": false

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -19,8 +19,8 @@
     },
     {
       "id": "boroughs",
-      "sql": "SELECT the_geom_webmercator, boroname FROM dcp_borough_boundary",
-      "dataPipeline": false
+      "sql": "SELECT the_geom_webmercator, boroname FROM nybb2020",
+      "dataPipeline": true
     },
     {
       "id": "dcp_city_council_districts",
@@ -45,17 +45,17 @@
     {
       "id": "cdtas",
       "sql": "SELECT the_geom_webmercator, cdtaname FROM nycdta2020",
-      "dataPipeline": false
+      "dataPipeline": true
     },
     {
       "id": "factfinder_dcp_community_districts",
-      "sql": "SELECT the_geom_webmercator, borocd, cd_short_title, borocd as geoid FROM cd_boundaries_v0_dh",
+      "sql": "SELECT the_geom_webmercator, borocd, borocd AS geolabel, borocd as geoid FROM nycd2020",
       "dataPipeline": true
     },
     {
       "id": "cities",
-      "sql": "SELECT the_geom_webmercator, id FROM nyc2020_sw_unofficial",
-      "dataPipeline": false
+      "sql": "SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM nycity2020",
+      "dataPipeline": true
     },
     {
       "id": "bk-qn-mh-boundary",

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -20,7 +20,7 @@
     {
       "id": "boroughs",
       "sql": "SELECT the_geom_webmercator, boroname FROM nybb2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "dcp_city_council_districts",
@@ -45,17 +45,17 @@
     {
       "id": "cdtas",
       "sql": "SELECT the_geom_webmercator, cdtaname FROM nycdta2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "factfinder_dcp_community_districts",
       "sql": "SELECT the_geom_webmercator, borocd, borocd AS geolabel, borocd as geoid FROM nycd2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "cities",
       "sql": "SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM nycity2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "bk-qn-mh-boundary",

--- a/data/sources/census-geoms-2020.json
+++ b/data/sources/census-geoms-2020.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "census-geoms-blocks",
-      "sql": "SELECT the_geom_webmercator, ct2010, borocode || ct2010 AS boroct2010, cb2010, borocode, bctcb2010, bctcb2010 AS geoid, bctcb2010 AS id, (ct2010::float / 100)::text || ' - ' || cb2010 as geolabel FROM dcp_census_blocks_2010",
+      "sql": "SELECT the_geom_webmercator, ct2020, borocode || ct2020 AS boroct2020, cb2020, boroname, borocode, bctcb2020, geoid AS geoid, geoid AS id, bctcb2020 as geolabel FROM nycb2020_fixed",
       "dataPipeline": true
     }
   ]

--- a/data/sources/census-geoms-2020.json
+++ b/data/sources/census-geoms-2020.json
@@ -5,12 +5,12 @@
     {
       "id": "census-geoms-tracts",
       "sql": "SELECT the_geom_webmercator, ct2020, ctlabel as geolabel, boroct2020, nta2020, boroct2020 AS geoid, boroct2020 AS id, 7 as pop, 9 as hh FROM nyct2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "census-geoms-blocks",
       "sql": "SELECT the_geom_webmercator, ct2020, borocode || ct2020 AS boroct2020, cb2020, boroname, borocode, bctcb2020, geoid AS geoid, geoid AS id, bctcb2020 as geolabel FROM nycb2020_fixed",
-      "dataPipeline": true
+      "dataPipeline": false
     }
   ]
 }


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR makes updates in preparation for updates to labs-factfinder:
 - Adds new geographies for the 2020 census update to factfinder
 - Updates sql queries to use the carto tables for 2020 geographies

Closes [AB#4282](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4282)
