### PR TITLE
Adding layers for zipcodes and cdta overlays

### DIFF
--- a/data/layer-groups/choropleths.json
+++ b/data/layer-groups/choropleths.json
@@ -4,7 +4,7 @@
   "titleTooltip": "Neighborhood Tabulation Area maps for selected variables",
   "visible": false,
   "legend": {
-    "label": "Thematic Maps (NTAs)",
+    "label": "Thematic Map",
     "icon": {
       "type": "line",
       "layers": [

--- a/data/layer-groups/community-district-tabulation-areas.json
+++ b/data/layer-groups/community-district-tabulation-areas.json
@@ -1,0 +1,120 @@
+{
+  "id": "cdta",
+  "legend": {
+    "label": "Community District Tabulation Areas (CDTAs)",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "#ed1212",
+          "stroke-width": 4,
+          "stroke-opacity": 0.3
+        },
+        {
+          "stroke": "#ed1212",
+          "stroke-width": 1.5,
+          "stroke-opacity": 0.6
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "cdta-line-glow",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "cdtas",
+        "paint": {
+          "line-color": "#ed1212",
+          "line-opacity": 0.3,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                4
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "cdta-line",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "cdtas",
+        "paint": {
+          "line-color": "#ed1212",
+          "line-opacity": 0.6,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                1
+              ],
+              [
+                16,
+                3
+              ]
+            ]
+          }
+        },
+        "layout": {
+          "line-join": "round",
+          "line-cap": "round"
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "cdta-label",
+        "type": "symbol",
+        "source": "admin-boundaries",
+        "source-layer": "cdta-centroids",
+        "minzoom": 12,
+        "paint": {
+          "text-color": "#626262",
+          "text-halo-color": "#FFFFFF",
+          "text-halo-width": 2,
+          "text-halo-blur": 2
+        },
+        "layout": {
+          "text-field": "{cdta}",
+          "text-font": [
+            "Open Sans Semibold",
+            "Arial Unicode MS Bold"
+          ],
+          "text-size": {
+            "stops": [
+              [
+                11,
+                12
+              ],
+              [
+                14,
+                16
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "neighborhood-tabulation-areas-fill",
+        "type": "fill",
+        "source": "admin-boundaries",
+        "source-layer": "cdtas",
+        "paint": {
+          "fill-opacity": 0.01
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/zip-codes.json
+++ b/data/layer-groups/zip-codes.json
@@ -1,0 +1,75 @@
+{
+  "id": "zip-codes",
+  "legend": {
+    "label": "Zipcodes",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "#ff6699",
+          "stroke-width": 4,
+          "stroke-opacity": 0.3
+        },
+        {
+          "stroke": "#ff6699",
+          "stroke-width": 1.5,
+          "stroke-opacity": 0.6
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "zip-code-line-glow",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "zip-codes",
+        "paint": {
+          "line-color": "#ff6699",
+          "line-opacity": 0.3,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                4
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "zip-code-line",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "codes",
+        "paint": {
+          "line-color": "#ff6699",
+          "line-opacity": 0.6,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                1
+              ],
+              [
+                16,
+                3
+              ]
+            ]
+          }
+        },
+        "layout": {
+          "line-join": "round",
+          "line-cap": "round"
+        }
+      }
+    }
+  ]
+}

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -23,6 +23,11 @@
       "dataPipeline": false
     },
     {
+      "id": "zip-codes",
+      "sql": "SELECT the_geom_webmercator, zipcode FROM nyc_zip_codes",
+      "dataPipeline": true
+    },
+    {
       "id": "dcp_city_council_districts",
       "sql": "SELECT the_geom_webmercator, coundist FROM dcp_city_council_districts",
       "dataPipeline": true
@@ -51,6 +56,11 @@
       "id": "cities",
       "sql": "SELECT the_geom_webmercator, id FROM nyc2020_sw_unofficial",
       "dataPipeline": false
+    },
+    {
+      "id": "cdta-centroids",
+      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, cdtaname FROM nycdta2020",
+      "dataPipeline": true
     },
     {
       "id": "bk-qn-mh-boundary",

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -25,7 +25,7 @@
     {
       "id": "zip-codes",
       "sql": "SELECT the_geom_webmercator, zipcode FROM nyc_zip_codes",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "dcp_city_council_districts",
@@ -60,7 +60,7 @@
     {
       "id": "cdta-centroids",
       "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, cdtaname FROM nycdta2020",
-      "dataPipeline": true
+      "dataPipeline": false
     },
     {
       "id": "bk-qn-mh-boundary",


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds new layers for cdtas and zipcodes

Changes Proposed:
- New json in layers-groups folder for the new overlay layers

Closes #AB4227, #AB3622

Supports/necessary for https://github.com/NYCPlanning/labs-factfinder/pull/868

- [X] Documentation has been created/updated to reflect changes in this PR
- [X] Tests have been written to prevent regressions or breaking changes
