### PR TITLE
4544 Point PFF-specific Layer Groups to PFF-specific Sources

### DIFF
--- a/data/layer-groups/factfinder--boroughs.json
+++ b/data/layer-groups/factfinder--boroughs.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--boroughs-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "boroughs",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "boroughs-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "boroughs",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "boroughs-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "boroughs",
         "minzoom": 11,
         "paint": {

--- a/data/layer-groups/factfinder--cdtas.json
+++ b/data/layer-groups/factfinder--cdtas.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--cdtas-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cdtas",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "cdtas-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cdtas",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "cdtas-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cdtas",
         "minzoom": 11,
         "paint": {

--- a/data/layer-groups/factfinder--cities.json
+++ b/data/layer-groups/factfinder--cities.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--cities-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cities",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "cities-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cities",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "cities-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "cities",
         "minzoom": 11,
         "paint": {

--- a/data/layer-groups/factfinder--districts.json
+++ b/data/layer-groups/factfinder--districts.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--districts-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "factfinder_dcp_community_districts",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "districts-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "factfinder_dcp_community_districts",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "districts-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "factfinder_dcp_community_districts",
         "minzoom": 11,
         "paint": {

--- a/data/layer-groups/factfinder--ntas.json
+++ b/data/layer-groups/factfinder--ntas.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--neighborhood-tabulation-areas-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "neighborhood-tabulation-areas",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "factfinder--nta-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "neighborhood-tabulation-areas",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "factfinder--nta-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "neighborhood-tabulation-areas-centroids",
         "minzoom": 12,
         "paint": {

--- a/data/layer-groups/factfinder--pumas.json
+++ b/data/layer-groups/factfinder--pumas.json
@@ -5,7 +5,7 @@
       "style": {
         "id": "factfinder--pumas-selection-fill",
         "type": "fill",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "dcp_puma",
         "paint": {
           "fill-opacity": 0.01
@@ -18,7 +18,7 @@
       "style": {
         "id": "factfinder--pumas-line",
         "type": "line",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "dcp_puma",
         "paint": {
           "line-color": "#444",
@@ -46,7 +46,7 @@
       "style": {
         "id": "factfinder--pumas-label",
         "type": "symbol",
-        "source": "admin-boundaries",
+        "source": "factfinder--admin-boundaries",
         "source-layer": "dcp_puma",
         "minzoom": 9,
         "paint": {

--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -19,13 +19,8 @@
     },
     {
       "id": "boroughs",
-      "sql": "SELECT the_geom_webmercator, boroname FROM nybb2020",
-      "dataPipeline": false
-    },
-    {
-      "id": "zip-codes",
-      "sql": "SELECT the_geom_webmercator, zipcode FROM nyc_zip_codes",
-      "dataPipeline": false
+      "sql": "SELECT the_geom_webmercator, boroname FROM dcp_borough_boundary",
+      "dataPipeline": true
     },
     {
       "id": "dcp_city_council_districts",
@@ -46,26 +41,6 @@
       "id": "dcp_puma",
       "sql": "SELECT the_geom_webmercator, puma, puma AS id, puma AS geoid FROM dcp_puma",
       "dataPipeline": true
-    },
-    {
-      "id": "cdtas",
-      "sql": "SELECT the_geom_webmercator, cdtaname FROM nycdta2020",
-      "dataPipeline": false
-    },
-    {
-      "id": "factfinder_dcp_community_districts",
-      "sql": "SELECT the_geom_webmercator, borocd, borocd AS geolabel, borocd as geoid FROM nycd2020",
-      "dataPipeline": false
-    },
-    {
-      "id": "cities",
-      "sql": "SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM nycity2020",
-      "dataPipeline": false
-    },
-    {
-      "id": "cdta-centroids",
-      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, cdtaname FROM nycdta2020",
-      "dataPipeline": false
     },
     {
       "id": "bk-qn-mh-boundary",

--- a/data/sources/factfinder--admin-boundaries.json
+++ b/data/sources/factfinder--admin-boundaries.json
@@ -1,0 +1,86 @@
+{
+  "id": "factfinder--admin-boundaries",
+  "type": "cartovector",
+  "source-layers": [
+    {
+      "id": "dcp_community_districts",
+      "sql": "SELECT the_geom_webmercator, borocd, CASE WHEN LEFT(borocd::text, 1) = '1' THEN 'Manhattan ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '2' THEN 'Bronx ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '3' THEN 'Brooklyn ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '4' THEN 'Queens ' || borocd % 100 WHEN LEFT(borocd::text, 1) = '5' THEN 'Staten Island ' || borocd % 100 END as boro_district FROM dcp_community_districts WHERE borocd % 100 < 20",
+      "dataPipeline": true
+    },
+    {
+      "id": "neighborhood-tabulation-areas",
+      "sql": "SELECT the_geom_webmercator, ntaname, ntaname AS id, a.nta2020 AS geoid FROM nynta2020 a WHERE ntaname NOT ILIKE 'park-cemetery-etc%' AND ntaname != 'Airport'",
+      "dataPipeline": false
+    },
+    {
+      "id": "neighborhood-tabulation-areas-centroids",
+      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM nynta2020 WHERE ntaname NOT ILIKE 'park-cemetery-etc%'",
+      "dataPipeline": false
+    },
+    {
+      "id": "boroughs",
+      "sql": "SELECT the_geom_webmercator, boroname FROM nybb2020",
+      "dataPipeline": false
+    },
+    {
+      "id": "zip-codes",
+      "sql": "SELECT the_geom_webmercator, zipcode FROM nyc_zip_codes",
+      "dataPipeline": false
+    },
+    {
+      "id": "dcp_city_council_districts",
+      "sql": "SELECT the_geom_webmercator, coundist FROM dcp_city_council_districts",
+      "dataPipeline": true
+    },
+    {
+      "id": "dcp_state_senate_districts",
+      "sql": "SELECT the_geom_webmercator, stsendist FROM dcp_state_senate_districts",
+      "dataPipeline": true
+    },
+    {
+      "id": "dcp_state_assembly_districts",
+      "sql": "SELECT the_geom_webmercator, assemdist FROM dcp_state_assembly_districts",
+      "dataPipeline": true
+    },
+    {
+      "id": "dcp_puma",
+      "sql": "SELECT the_geom_webmercator, puma, puma AS id, puma AS geoid FROM dcp_puma",
+      "dataPipeline": true
+    },
+    {
+      "id": "cdtas",
+      "sql": "SELECT the_geom_webmercator, cdtaname FROM nycdta2020",
+      "dataPipeline": false
+    },
+    {
+      "id": "factfinder_dcp_community_districts",
+      "sql": "SELECT the_geom_webmercator, borocd, borocd AS geolabel, borocd as geoid FROM nycd2020",
+      "dataPipeline": false
+    },
+    {
+      "id": "cities",
+      "sql": "SELECT the_geom_webmercator, city AS geolabel, city AS geoid FROM nycity2020",
+      "dataPipeline": false
+    },
+    {
+      "id": "cdta-centroids",
+      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, cdtaname FROM nycdta2020",
+      "dataPipeline": false
+    },
+    {
+      "id": "bk-qn-mh-boundary",
+      "sql": "SELECT the_geom_webmercator, label1 || '/' || label2 AS boro_boundary FROM bk_qn_mh_boundary"
+    }
+  ],
+  "minzoom": 0,
+  "buffersize": {
+    "mvt": 10
+  },
+  "meta": {
+    "description": "Administrative and Political Districts v18D, Bytes of the Big Apple",
+    "url": [
+      "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
+    ],
+    "updated_at": "February 2021"
+  }
+}


### PR DESCRIPTION
### Summary
Previously Factfinder specific Layer Groups pointed to the general admin boundary source, and changes were made to that admin boundary source. This is dangerous because the admin boundary source pointed to ad hoc Factfinder Carto layers. This can affect other apps that depend on the older, official geographies. 

This moves those changes to the admin boundary source to `factfinder--admin-boundaries`, which is specific to Factfinder. It then points PFF Layer Groups to this new PFF specific source.

#### Tasks/Bug Numbers
 - Fixes [AB#4544](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4544)
