### PR TITLE
4869 Include geoid prop for PFF boroughs and cdtas

### DIFF
--- a/data/sources/factfinder--admin-boundaries.json
+++ b/data/sources/factfinder--admin-boundaries.json
@@ -19,7 +19,7 @@
     },
     {
       "id": "boroughs",
-      "sql": "SELECT the_geom_webmercator, boroname FROM pff_2020_boroughs_21c",
+      "sql": "SELECT the_geom_webmercator, boroname, borocode AS geoid FROM pff_2020_boroughs_21c",
       "dataPipeline": false
     },
     {
@@ -49,7 +49,7 @@
     },
     {
       "id": "cdtas",
-      "sql": "SELECT the_geom_webmercator, cdtaname FROM pff_2020_cdtas_21c",
+      "sql": "SELECT the_geom_webmercator, cdtaname, cdtaname AS geolabel, cdta2020, cdtatype, boroname, borocode::text, cdta2020 AS geoid FROM pff_2020_cdtas_21c",
       "dataPipeline": false
     },
     {


### PR DESCRIPTION
### Summary
The new Factfinder frontend depends on the geoid property on boroughs and cdta layers (as with all other layers). These were not included in the borough and cdta layers delievered to the frontend, thus the borough and cdta selection wasn't working. 

This PR changes the properties SELECTed on those layers to match what is in [queries/summary-levels](https://github.com/NYCPlanning/labs-factfinder/blob/develop/app/queries/summary-levels.js). Other properties are included for convenience, just in case the frontend relies on them.  

#### Tasks/Bug Numbers
 - Fixes [AB#4869](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4869)
