### PR TITLE
5288 Create Factfinder-specific layer groups for ntas, zip codes, community districts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,12 @@ Anonymous maps from the Carto Maps API are generated on each request to the `/la
 
 See the `getVectorTileTemplate` funtion within `utils/carto.js`. 
 
-### One-Off Sources
-[Population Factfinder](https://github.com/NYCPlanning/labs-factfinder/) relies on a one-off layers that uses geojson of NTAs along with various data from the ACS and Decennial census. This geojson is kept directly in `./data/sources`. The code and
+### Population Factfinder Layer Groups and Sources
+[Population Factfinder](https://github.com/NYCPlanning/labs-factfinder/) relies on a "one-off", factfinder-specific Layer Groups and Sources in the Layers API. These are necessary for Factfinder-specific adjustments to these layers (legend title, slight styling changes) that should not affect other apps.
+
+These Layer Groups and Sources have the prefix `factfinder--`. For example, `layer-groups/factfinder--neighborhood-tabulation-areas.json`
+
+Some of thse PFF layers/sources use geojson of NTAs along with various data from the ACS and Decennial census. This geojson is kept directly in `./data/sources`. The code and
 documentation on how to generate or update this data is found in the jupyter notebook `./data/etl/build_choropleths.ipynb`.
 
 ## Schemas

--- a/data/layer-groups/factfinder--community-districts.json
+++ b/data/layer-groups/factfinder--community-districts.json
@@ -1,0 +1,109 @@
+{
+  "id": "factfinder--community_districts",
+  "legend": {
+    "label": "Community Districts (CDs)",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "#a5ed12",
+          "stroke-width": 4,
+          "stroke-opacity": 0.5
+        },
+        {
+          "stroke": "#527a00",
+          "stroke-width": 1.5,
+          "stroke-opacity": 0.8
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "dcp_community_districts-line-glow",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "dcp_community_districts",
+        "paint": {
+          "line-color": "#a5ed12",
+          "line-opacity": 0.5,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                4
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "dcp_community_districts-line",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "dcp_community_districts",
+        "paint": {
+          "line-color": "#527a00",
+          "line-opacity": 0.8,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                1
+              ],
+              [
+                16,
+                3
+              ]
+            ]
+          }
+        },
+        "layout": {
+          "line-join": "round",
+          "line-cap": "round"
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "dcp_community_districts-label",
+        "type": "symbol",
+        "source": "admin-boundaries",
+        "source-layer": "dcp_community_districts",
+        "minzoom": 11,
+        "paint": {
+          "text-color": "#626262",
+          "text-halo-color": "#FFFFFF",
+          "text-halo-width": 2,
+          "text-halo-blur": 2
+        },
+        "layout": {
+          "text-field": "{boro_district}",
+          "text-font": [
+            "Open Sans Semibold",
+            "Arial Unicode MS Bold"
+          ],
+          "text-size": {
+            "stops": [
+              [
+                11,
+                12
+              ],
+              [
+                14,
+                16
+              ]
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/factfinder--neighborhood-tabulation-areas.json
+++ b/data/layer-groups/factfinder--neighborhood-tabulation-areas.json
@@ -1,0 +1,120 @@
+{
+  "id": "factfinder--neighborhood-tabulation-areas",
+  "legend": {
+    "label": "Neighborhood Tabulation Areas (NTAs)",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "#2929ed",
+          "stroke-width": 4,
+          "stroke-opacity": 0.3
+        },
+        {
+          "stroke": "#00007a",
+          "stroke-width": 1.5,
+          "stroke-opacity": 0.6
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "nta-line-glow",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "neighborhood-tabulation-areas",
+        "paint": {
+          "line-color": "#2929ed",
+          "line-opacity": 0.3,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                4
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "nta-line",
+        "type": "line",
+        "source": "admin-boundaries",
+        "source-layer": "neighborhood-tabulation-areas",
+        "paint": {
+          "line-color": "#00007a",
+          "line-opacity": 0.6,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                1
+              ],
+              [
+                16,
+                3
+              ]
+            ]
+          }
+        },
+        "layout": {
+          "line-join": "round",
+          "line-cap": "round"
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "nta-label",
+        "type": "symbol",
+        "source": "admin-boundaries",
+        "source-layer": "neighborhood-tabulation-areas-centroids",
+        "minzoom": 12,
+        "paint": {
+          "text-color": "#626262",
+          "text-halo-color": "#FFFFFF",
+          "text-halo-width": 2,
+          "text-halo-blur": 2
+        },
+        "layout": {
+          "text-field": "{ntaname}",
+          "text-font": [
+            "Open Sans Semibold",
+            "Arial Unicode MS Bold"
+          ],
+          "text-size": {
+            "stops": [
+              [
+                11,
+                12
+              ],
+              [
+                14,
+                16
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "neighborhood-tabulation-areas-fill",
+        "type": "fill",
+        "source": "admin-boundaries",
+        "source-layer": "neighborhood-tabulation-areas",
+        "paint": {
+          "fill-opacity": 0.01
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/factfinder--zip-codes.json
+++ b/data/layer-groups/factfinder--zip-codes.json
@@ -1,0 +1,75 @@
+{
+  "id": "factfinder--zip-codes",
+  "legend": {
+    "label": "ZIP Codes",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "#ff6699",
+          "stroke-width": 4,
+          "stroke-opacity": 0.3
+        },
+        {
+          "stroke": "#ff6699",
+          "stroke-width": 1.5,
+          "stroke-opacity": 0.6
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "zip-code-line-glow",
+        "type": "line",
+        "source": "factfinder--admin-boundaries",
+        "source-layer": "zip-codes",
+        "paint": {
+          "line-color": "#ff6699",
+          "line-opacity": 0.3,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                4
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "zip-code-line",
+        "type": "line",
+        "source": "factfinder--admin-boundaries",
+        "source-layer": "codes",
+        "paint": {
+          "line-color": "#ff6699",
+          "line-opacity": 0.6,
+          "line-width": {
+            "stops": [
+              [
+                11,
+                1
+              ],
+              [
+                16,
+                3
+              ]
+            ]
+          }
+        },
+        "layout": {
+          "line-join": "round",
+          "line-cap": "round"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Creates 3 new Population Factfinder-specific layer groups. They are duplicates of neighborhood-tabulation-areas, zip-codes, and community-districts. The only difference is the legend label, which is adjusted for PFF use. 

#### Tasks/Bug Numbers
 - Fixes [AB#5288](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5288)
