### PR TITLE
Updating pff block query to use correct field for geoid

### DIFF
--- a/data/sources/census-geoms-2020.json
+++ b/data/sources/census-geoms-2020.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "census-geoms-blocks",
-      "sql": "SELECT the_geom_webmercator, ct2020, borocode || ct2020 AS boroct2020, cb2020, boroname, borocode, bctcb2020, geoid AS geoid, geoid AS id, bctcb2020 as geolabel FROM pff_2020_census_blocks_21c",
+      "sql": "SELECT the_geom_webmercator, ct2020, borocode || ct2020 AS boroct2020, cb2020, boroname, borocode, bctcb2020, bctcb2020 AS geoid, geoid AS id, bctcb2020 as geolabel FROM pff_2020_census_blocks_21c",
       "dataPipeline": false
     }
   ]


### PR DESCRIPTION
### Summary
This updates the query for pff census blocks to use the bctcb2020 field as the geoid instead of the actual geoid column
