### PR TITLE
5292 Match styles of PFF CDTA and NTA labels to subdued_nta_labels in PFF

### DIFF
--- a/data/layer-groups/factfinder--cdtas.json
+++ b/data/layer-groups/factfinder--cdtas.json
@@ -55,28 +55,31 @@
             ["linear"],
             ["zoom"],
             12,
-            "#d3d3d3",
+            "hsl(0, 0%, 62%)",
             13,
-            "#626262"
+            "hsl(0, 0%, 0%)"
           ],
-          "text-halo-color": "#FFFFFF",
-          "text-halo-width": 2,
-          "text-halo-blur": 2
+          "text-halo-color": "hsl(0, 0%, 100%)",
+          "text-halo-width": 1,
+          "text-halo-blur": 0
         },
         "layout": {
           "text-field": "{cdtaname}",
+          "text-transform": "uppercase",
           "text-font": [
-            "Open Sans Semibold",
-            "Arial Unicode MS Bold"
+            "Arial Unicode MS Regular"
           ],
+          "text-max-width": 7,
+          "text-padding": 3,
           "text-size": {
+            "base": 1,
             "stops": [
               [
-                11,
-                12
+                12,
+                11
               ],
               [
-                14,
+                16,
                 16
               ]
             ]

--- a/data/layer-groups/factfinder--ntas.json
+++ b/data/layer-groups/factfinder--ntas.json
@@ -54,28 +54,31 @@
             ["linear"],
             ["zoom"],
             12,
-            "#d3d3d3",
+            "hsl(0, 0%, 62%)",
             13,
-            "#626262"
+            "hsl(0, 0%, 0%)"
           ],
-          "text-halo-color": "#FFFFFF",
-          "text-halo-width": 2,
-          "text-halo-blur": 2
+          "text-halo-color": "hsl(0, 0%, 100%)",
+          "text-halo-width": 1,
+          "text-halo-blur": 0
         },
         "layout": {
           "text-field": "{ntaname}",
+          "text-transform": "uppercase",
           "text-font": [
-            "Open Sans Semibold",
-            "Arial Unicode MS Bold"
+            "Arial Unicode MS Regular"
           ],
+          "text-max-width": 7,
+          "text-padding": 3,
           "text-size": {
+            "base": 1,
             "stops": [
               [
-                11,
-                12
+                12,
+                11
               ],
               [
-                14,
+                16,
                 16
               ]
             ]


### PR DESCRIPTION
### Summary
Updates the PFF NTA and CDTA labels to match the style used for "subdued nta labels" displayed in PFF for census tracts (see third image below). 
Requested by Erica. 
Took the styles from `labs-factfinder//app/layers/subdued-nta-labels.js`

#### Tasks/Bug Numbers
 - Fixes [AB#5292](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5292)

![image](https://user-images.githubusercontent.com/3311663/137550656-c287f46e-9748-4885-9e97-7a42ef3f44ce.png)
![image](https://user-images.githubusercontent.com/3311663/137550685-655daef9-32d8-4c0e-9420-322399fa29d4.png)
![image](https://user-images.githubusercontent.com/3311663/137550671-1daaa9ff-fe9e-48a6-a3a3-03b4591d9122.png)
