### PR TITLE
Load static JSON file from local disk each time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 .DS_Store
 newrelic_agent.log
+.env

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "migrate-meta": "node ./tasks/migrate-meta-from-layer-group-to-source.js"
   },
   "engines": {
-    "node": "^8.11.3"
+    "node": "^8.* || >= 12"
   }
 }

--- a/routes/v1/base.js
+++ b/routes/v1/base.js
@@ -1,11 +1,14 @@
 const Router = require('koa-router');
-const style = require('../../data/base/style.json');
-
+const { sync: loadJsonFile } = require('load-json-file');
+const path = require('path');
 const router = new Router();
-
 const HOST = process.env.HOST || 'http://localhost:3000';
 
 router.get('/style.json', async (ctx) => {
+  const style = loadJsonFile(
+    path.resolve(__dirname, `../../data/base/style.json`),
+  );
+
   style.sources.openmaptiles.url = style.sources.openmaptiles.url.replace('{{HOSTNAME}}', HOST);
   style.sprite = style.sprite.replace('{{HOSTNAME}}', HOST);
 


### PR DESCRIPTION
Addresses https://github.com/NYCPlanning/labs-layers-api/issues/253 by loading the style.json from local disk each time the route is called.

There may still be other memory leak issues throughout the app wherever `style.json` is imported, but this addresses the biggest concern...