### PR TITLE
2844 Add Shaded X zones to floodplain maps

### DIFF
--- a/data/layer-groups/floodplain-efirm2007.json
+++ b/data/layer-groups/floodplain-efirm2007.json
@@ -7,7 +7,7 @@
     "items": [
       {
         "label": "V Zone",
-        "tooltip": "Portion of the 1% annual chance floodplain subject to high velocity wave action (a breaking wave 3 feet high or larger). V Zones are subject to more stringent building requirements than other zones because of the damaging force of waves.",
+        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood and referred to in the Zoning Resolution as the 'high-risk flood zone'. These areas are subject to high velocity wave action (a breaking wave 3 feet high or larger).",
         "icon": {
           "type": "fa-icon",
           "layers": [
@@ -20,13 +20,26 @@
       },
       {
         "label": "A Zone",
-        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood. These areas are not subject to high velocity wave action but are still considered high risk flooding areas.",
+        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood and referred to in the Zoning Resolution as the 'high-risk flood zone'. These areas are not subject to high velocity wave action but are still considered high risk flooding areas.",
         "icon": {
           "type": "fa-icon",
           "layers": [
             {
               "fa-icon": "square",
               "color": "#00a9e6"
+            }
+          ]
+        }
+      },
+      {
+        "label": "Shaded X Zone",
+        "tooltip": "The area subject to flooding from the 0.2% annual chance flood and referred to in the Zoning Resolution as the 'moderate-risk flood zone'.",
+        "icon": {
+          "type": "fa-icon",
+          "layers": [
+            {
+              "fa-icon": "square",
+              "color": "rgb(0, 255, 197)"
             }
           ]
         }
@@ -52,6 +65,10 @@
               [
                 "A",
                 "#00a9e6"
+              ],
+              [
+                "Shaded X",
+                "#00ffc3"
               ]
             ]
           },

--- a/data/layer-groups/floodplain-pfirm2015.json
+++ b/data/layer-groups/floodplain-pfirm2015.json
@@ -7,7 +7,7 @@
     "items": [
       {
         "label": "V Zone",
-        "tooltip": "Portion of the 1% annual chance floodplain subject to high velocity wave action (a breaking wave 3 feet high or larger). V Zones are subject to more stringent building requirements than other zones because of the damaging force of waves.",
+        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood and referred to in the Zoning Resolution as the 'high-risk flood zone'. These areas are subject to high velocity wave action (a breaking wave 3 feet high or larger).",
         "icon": {
           "type": "fa-icon",
           "layers": [
@@ -20,7 +20,7 @@
       },
       {
         "label": "A Zone",
-        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood. These areas are not subject to high velocity wave action but are still considered high risk flooding areas.",
+        "tooltip": "A portion of the area subject to flooding from the 1% annual chance flood and referred to in the Zoning Resolution as the 'high-risk flood zone'. These areas are not subject to high velocity wave action but are still considered high risk flooding areas.",
         "icon": {
           "type": "fa-icon",
           "layers": [
@@ -30,8 +30,20 @@
             }
           ]
         }
-      }
-    ]
+      },
+      {
+        "label": "Shaded X Zone",
+        "tooltip": "The area subject to flooding from the 0.2% annual chance flood and referred to in the Zoning Resolution as the 'moderate-risk flood zone'.",
+        "icon": {
+          "type": "fa-icon",
+          "layers": [
+            {
+              "fa-icon": "square",
+              "color": "rgb(0, 255, 197)"
+            }
+          ]
+        }
+    }]
   },
   "layers": [
     {
@@ -52,6 +64,10 @@
               [
                 "A",
                 "#00a9e6"
+              ],
+              [
+                "Shaded X",
+                "#00ffc3"
               ]
             ]
           },

--- a/data/sources/floodplains.json
+++ b/data/sources/floodplains.json
@@ -4,11 +4,11 @@
   "source-layers": [
     {
       "id": "effective-flood-insurance-rate-2007",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM fema_firm WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' OR fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD'"
     },
     {
       "id": "preliminary-flood-insurance-rate",
-      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' "
+      "sql": "SELECT the_geom_webmercator, cartodb_id AS id, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM fema_pfirm WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' OR fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD'"
     }
   ],
   "meta": {


### PR DESCRIPTION
### Summary
Adds Shaded X (or "0.2% flood chance") values to the firm (2007) and pfirm (2015) layers.

Updates the firm and pfirm sources to use the new EDM Pipeline fema_firm and fema_pfirm carto layers.

The layers are truly a mess. There's a duplicate layers in both frontend and backend. The layer slugs are also a mess and need updating. However it requires updates to the frontend as well. 

Does not yet create separate toggles for each flood category. 

#### Tasks/Bug Numbers
 - Fixes [AB#2844](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2844)
