### PR TITLE
Update nta source to point to 2020 data set in Carto

### DIFF
--- a/data/sources/admin-boundaries.json
+++ b/data/sources/admin-boundaries.json
@@ -9,12 +9,12 @@
     },
     {
       "id": "neighborhood-tabulation-areas",
-      "sql": "SELECT the_geom_webmercator, ntaname, ntaname AS id, a.ntacode AS geoid FROM dcp_nta a WHERE ntaname NOT ILIKE 'park-cemetery-etc%' AND ntaname != 'Airport'",
+      "sql": "SELECT the_geom_webmercator, ntaname, ntaname AS id, a.nta2020 AS geoid FROM dcp_nta_2020 a WHERE ntaname NOT ILIKE 'park-cemetery-etc%' AND ntaname != 'Airport'",
       "dataPipeline": true
     },
     {
       "id": "neighborhood-tabulation-areas-centroids",
-      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM dcp_nta WHERE ntaname NOT ILIKE 'park-cemetery-etc%'",
+      "sql": "SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM dcp_nta_2020 WHERE ntaname NOT ILIKE 'park-cemetery-etc%'",
       "dataPipeline": true
     },
     {


### PR DESCRIPTION
### Summary
This PR updates the NTA data source to point to the new `dcp_nta_2020` dataset in Carto so that it shows 2020 NTAs, instead of 2010. As far as I can tell, the layer groups that reference this source are only used by Zola, however note that there are separate data sources and layer groups for PFF, some of which reference other NTA Carto datasets.