### PR TITLE
10294 – Change stair and paper street layer filters to match variable names on Carto

### DIFF
--- a/data/layer-groups/paper-streets.json
+++ b/data/layer-groups/paper-streets.json
@@ -68,7 +68,7 @@
           "all",
           [
             "==",
-            "feature_st",
+            "feat_statu",
             "Paper_St"
           ]
         ],

--- a/data/layer-groups/paper-streets.json
+++ b/data/layer-groups/paper-streets.json
@@ -25,7 +25,7 @@
           "all",
           [
             "==",
-            "feature_st",
+            "feat_statu",
             "Paper_St"
           ]
         ],

--- a/data/layer-groups/stair-streets.json
+++ b/data/layer-groups/stair-streets.json
@@ -25,7 +25,7 @@
           "all",
           [
             "==",
-            "roadway_ty",
+            "roadwaytyp",
             "Step_Stair_ST"
           ]
         ],
@@ -85,7 +85,7 @@
           "all",
           [
             "==",
-            "roadway_ty",
+            "roadwaytyp",
             "Step_Stair_ST"
           ]
         ],


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
Stair and paper street layers were not being displayed in NYC Streets app. The issue was that the filters for these layers no longer matched the current variable names on Carto. 

#### Tasks/Bug Numbers
 - Fixes AB[#10294](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=10294)

Streets App:
![Screen Shot 2022-08-26 at 11 44 29 AM](https://user-images.githubusercontent.com/43344288/186943160-a3fca848-b937-4649-a522-5aecb465c927.png)

