### PR TITLE
11999 – Remove ULURP and CEQR numbers from e-designation tooltips

### DIFF
--- a/data/layer-groups/e-designations.json
+++ b/data/layer-groups/e-designations.json
@@ -61,7 +61,7 @@
       "highlightable": true,
       "clickable": true,
       "tooltipable": true,
-      "tooltipTemplate": "{{fa-icon 'external-link-alt'}} E-designation, E-Number: {{{enumber}}}, CEQR: {{{ceqr_num}}}, ULURP: {{{ulurp_num}}}"
+      "tooltipTemplate": "{{fa-icon 'external-link-alt'}} E-designation, E-Number: {{{enumber}}}"
     },
     {
       "style": {


### PR DESCRIPTION
Part of AB[#11999](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/23B?workitem=11999). Updates e-designation tooltip template to no longer include ULURP or CEQR numbers.

Holding off on merging until the new E-Designation Info Panel is also ready.
