### PR TITLE
14977 removed data references in description for the ZoLa Data sources

### DIFF
--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -86,7 +86,7 @@
       "mvt": 10
     },
     "meta": {
-      "description": "Zoning related datasets December 2022, Bytes of the Big Apple",
+      "description": "Zoning related datasets, Bytes of the Big Apple",
       "url": [
         "https://www1.nyc.gov/site/planning/data-maps/open-data.page#zoning_related"
       ],

--- a/data/sources/zoning-districts.json
+++ b/data/sources/zoning-districts.json
@@ -12,7 +12,7 @@
     "mvt": 10
   },
   "meta": {
-    "description": "NYC GIS Zoning Features March 2023, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
     ],

--- a/data/sources/zoning-map-amendments.json
+++ b/data/sources/zoning-map-amendments.json
@@ -17,7 +17,7 @@
     "mvt": 10
   },
   "meta": {
-    "description": "NYC GIS Zoning Features December 2022, Bytes of the Big Apple",
+    "description": "NYC GIS Zoning Features, Bytes of the Big Apple",
     "url": [
       "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page"
     ],


### PR DESCRIPTION
### Summary

This PR removes the date from the `meta.description`   from the Data Source JSON

#### Tasks/Bug Numbers
 - [AB#14799](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/14977)
