### PR TITLE
Update ZFA layer fill color and opacity to match Figma specs

### DIFF
--- a/data/layer-groups/zoning-for-accessibility.json
+++ b/data/layer-groups/zoning-for-accessibility.json
@@ -41,20 +41,8 @@
         "source": "supporting-zoning",
         "source-layer": "zoning-for-accessibility",
         "paint": {
-          "fill-color": "rgba(0, 57, 16, 0.5)",
-          "fill-opacity": {
-              "stops": [
-                [
-                  15,
-                  0.1
-                ],
-                [
-                  16,
-                  0.1
-                ]
-              ]
-            },
-            "fill-antialias": true
+          "fill-color": "rgba(0, 57, 165, 0.2)",
+          "fill-antialias": true
         }
       }
     }


### PR DESCRIPTION
### Summary
Updates the color and opacity of the ZFA layer fill to match Figma specs. Previously, the RGB color value was incorrect and the layer had an unnecessary `fill-opacity` setting that compounded the alpha value in the RGBA in `fill-color`, resulting compounding alphas therefore making the layer too transparent.