### PR TITLE
377 Add 2024 orthos

### DIFF
--- a/data/layer-groups/aerials.json
+++ b/data/layer-groups/aerials.json
@@ -8,6 +8,18 @@
   "layers": [
     {
       "before": "boundary_state",
+      "displayName": "2024",
+      "style": {
+        "id": "aerials-2024",
+        "layout": {
+          "visibility": "visible"
+        },
+        "source": "aerials-2024",
+        "type": "raster"
+      }
+    },
+    {
+      "before": "boundary_state",
       "displayName": "2022",
       "style": {
         "id": "aerials-2022",

--- a/data/sources/aerials-2024.json
+++ b/data/sources/aerials-2024.json
@@ -1,0 +1,15 @@
+{
+    "id": "aerials-2024",
+    "type": "raster",
+    "tiles": [
+      "https://tiles.arcgis.com/tiles/yG5s3afENB5iO9fj/arcgis/rest/services/NYC_Orthos_2024/MapServer/tile/{z}/{y}/{x}"
+    ],
+    "tileSize": 256,
+    "meta": {
+      "description": "NYC OTI GIS Aerial Photography Tile Layers (TMS)",
+      "url": [
+        "https://tiles.arcgis.com/tiles/"
+    ],
+      "updated_at": "n/a"
+    }
+  }


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
# Acceptance Criteria

- [ ] Update sources and layer groups to include new 2024 ortho data. Example code can be found in [this PR](https://github.com/NYCPlanning/labs-layers-api/pull/334/files#diff-240c924952d43853773787c42203a0c302391bf412c9a54c9971280ec1835968) but note that PR migrated existing orthos to a new source - this change is just adding the new 2024 layer

The page for the 2024 ortho data on OTI's GIS Hub can be found [here](https://nyc.maps.arcgis.com/home/item.html?id=423f15185bd04f8dad8d99fba736772f). The URL to add to the new `source` can be found under "Details" and "URL" on the right hand side of that page.

#### Tasks/Bug Numbers
 - Completes #377 
