### PR TITLE
Task/1301 replace subway layer with transit layer

### DIFF
--- a/data/layer-groups/mta-lirr-rail-lines.json
+++ b/data/layer-groups/mta-lirr-rail-lines.json
@@ -1,0 +1,40 @@
+{
+  "id": "lirr-rail-lines",
+  "legend": {
+    "label": "LIRR",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "rgba(69, 76, 82, 1)",
+          "stroke-width": 2
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "lirr_black",
+        "source": "transportation",
+        "source-layer": "lirr-routes",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/mta-metronorth-rail-lines.json
+++ b/data/layer-groups/mta-metronorth-rail-lines.json
@@ -1,0 +1,40 @@
+{
+  "id": "metronorth-rail-lines",
+  "legend": {
+    "label": "metronorth",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "rgba(238, 53, 46, 1)",
+          "stroke-width": 2
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "metronorth_black",
+        "source": "transportation",
+        "source-layer": "metronorth-routes",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/path-rail-routes.json
+++ b/data/layer-groups/path-rail-routes.json
@@ -1,0 +1,128 @@
+{
+  "id": "path-rail-routes",
+  "legend": {
+    "label": "PATH",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "rgba(69, 76, 82, 1)",
+          "stroke-width": 2
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "path_rail_gray",
+        "source": "transportation",
+        "source-layer": "path-rail-routes",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_stations",
+        "minzoom": 11,
+        "source": "transportation",
+        "source-layer": "path-rail-stops",
+        "type": "circle",
+        "paint": {
+          "circle-color": "rgba(255, 255, 255, 1)",
+          "circle-opacity": {
+            "stops": [
+              [
+                11,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          },
+          "circle-stroke-opacity": {
+            "stops": [
+              [
+                11,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          },
+          "circle-radius": {
+            "stops": [
+              [
+                10,
+                2
+              ],
+              [
+                14,
+                5
+              ]
+            ]
+          },
+          "circle-stroke-width": 1,
+          "circle-pitch-scale": "map"
+        }
+      }
+    },
+    {
+      "before": "place_other",
+      "style": {
+        "id": "station",
+        "minzoom": 13,
+        "source": "transportation",
+        "source-layer": "path-rail-stops",
+        "type": "symbol",
+        "layout": {
+          "text-field": "{station}",
+          "symbol-placement": "point",
+          "symbol-spacing": 250,
+          "symbol-avoid-edges": false,
+          "text-size": 14,
+          "text-anchor": "center"
+        },
+        "paint": {
+          "text-halo-color": "rgba(255, 255, 255, 1)",
+          "text-halo-width": 1,
+          "text-translate": [
+            1,
+            20
+          ],
+          "text-opacity": {
+            "stops": [
+              [
+                13,
+                0
+              ],
+              [
+                14,
+                1
+              ]
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/data/layer-groups/unified-transit-lines.json
+++ b/data/layer-groups/unified-transit-lines.json
@@ -1,0 +1,534 @@
+{
+  "id": "unified-transit-lines",
+  "legend": {
+    "label": "Transit",
+    "tooltip": "Subways, LIRR, MNR, PATH",
+    "icon": {
+      "type": "line",
+      "layers": [
+        {
+          "stroke": "rgba(238, 53, 46, 1)",
+          "stroke-width": 2
+        }
+      ]
+    }
+  },
+  "layers": [
+    {
+      "style": {
+        "id": "subway_green",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "4"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(0, 147, 60, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_yellow",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "N"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(252, 204, 10, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_gray",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "L"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(167, 169, 172, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_brown",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "J"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(153, 102, 51, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_light_green",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "G"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(108, 190, 69, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_orange",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "B"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(255, 99, 25, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_blue",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "any",
+          [
+            "==",
+            "rt_symbol",
+            "A"
+          ],
+          [
+            "==",
+            "rt_symbol",
+            "SI"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(0, 57, 166, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_purple",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "7"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(185, 51, 173, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_red",
+        "source": "transportation",
+        "source-layer": "subway-routes",
+        "type": "line",
+        "filter": [
+          "all",
+          [
+            "==",
+            "rt_symbol",
+            "1"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(238, 53, 46, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "subway_stations",
+        "minzoom": 11,
+        "source": "transportation",
+        "source-layer": "station-envelope-point-on-surfaces",
+        "type": "circle",
+        "paint": {
+          "circle-color": "rgba(255, 255, 255, 1)",
+          "circle-opacity": {
+            "stops": [
+              [
+                11,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          },
+          "circle-stroke-opacity": {
+            "stops": [
+              [
+                11,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          },
+          "circle-radius": {
+            "stops": [
+              [
+                10,
+                2
+              ],
+              [
+                14,
+                5
+              ]
+            ]
+          },
+          "circle-stroke-width": 1,
+          "circle-pitch-scale": "map"
+        }
+      }
+    },
+    {
+      "before": "place_other",
+      "style": {
+        "id": "subway_stations_labels",
+        "minzoom": 13,
+        "source": "transportation",
+        "source-layer": "station-envelope-point-on-surfaces",
+        "type": "symbol",
+        "layout": {
+          "text-field": "{station_name}",
+          "symbol-placement": "point",
+          "symbol-spacing": 250,
+          "symbol-avoid-edges": false,
+          "text-size": 14,
+          "text-anchor": "center"
+        },
+        "paint": {
+          "text-halo-color": "rgba(255, 255, 255, 1)",
+          "text-halo-width": 1,
+          "text-translate": [
+            1,
+            20
+          ],
+          "text-opacity": {
+            "stops": [
+              [
+                13,
+                0
+              ],
+              [
+                14,
+                1
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "lirr_rail_lines",
+        "source": "transportation",
+        "source-layer": "mta-lirr-rail-lines",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "metronorth_rail_lines",
+        "source": "transportation",
+        "source-layer": "mta-metronorth-rail-lines",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "path_routes",
+        "source": "transportation",
+        "source-layer": "path-rail-routes",
+        "type": "line",
+        "paint": {
+          "line-color": "rgba(69, 76, 82, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                15,
+                4
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "before": "place_other",
+      "style": {
+        "id": "path_stations_labels",
+        "minzoom": 13,
+        "source": "transportation",
+        "source-layer": "station-envelope-point-on-surfaces",
+        "type": "symbol",
+        "layout": {
+          "text-field": "{station_name}",
+          "symbol-placement": "point",
+          "symbol-spacing": 250,
+          "symbol-avoid-edges": false,
+          "text-size": 14,
+          "text-anchor": "center"
+        },
+        "paint": {
+          "text-halo-color": "rgba(255, 255, 255, 1)",
+          "text-halo-width": 1,
+          "text-translate": [
+            1,
+            20
+          ],
+          "text-opacity": {
+            "stops": [
+              [
+                13,
+                0
+              ],
+              [
+                14,
+                1
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "before": "place_state",
+      "style": {
+        "id": "station_envelope_line",
+        "minzoom": 16,
+        "type": "line",
+        "source": "transportation",
+        "source-layer": "station-envelope",
+        "paint": {
+          "line-width": {
+            "stops": [
+              [
+                11,
+                0.5
+              ],
+              [
+                12,
+                1.5
+              ]
+            ]
+          },
+          "line-color": "#FD0004"
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "station_envelope_fill",
+        "minzoom": 16,
+        "type": "fill",
+        "source": "transportation",
+        "source-layer": "station-envelope",
+        "paint": {
+          "fill-color": "rgba(253, 0, 4, 0.2)",
+          "fill-antialias": true
+        }
+      }
+    }
+  ]
+}

--- a/data/sources/transportation.json
+++ b/data/sources/transportation.json
@@ -4,24 +4,48 @@
   "source-layers": [
     {
       "id": "bike-routes",
-      "sql": "SELECT the_geom_webmercator, cartodb_id FROM bike_routes"
+      "sql": "SELECT the_geom_webmercator, cartodb_id FROM bike_routes",
+      "dataPipeline": true
+    },
+    {
+      "id": "subway-lines",
+      "sql": "SELECT the_geom_webmercator, oem_route FROM mta_nycta_subway_lines",
+      "dataPipeline": true
     },
     {
       "id": "subway-routes",
-      "sql": "SELECT the_geom_webmercator, rt_symbol FROM mta_subway_routes"
+      "sql": "SELECT the_geom_webmercator, rt_symbol FROM mta_subway_routes",
+      "dataPipeline": true
     },
     {
-      "id": "subway-stops",
-      "sql": "SELECT the_geom_webmercator, name FROM mta_subway_stops"
+      "id": "mta-lirr-rail-lines",
+      "sql": "SELECT the_geom_webmercator, cartodb_id, route FROM mta_lirr_rail_lines",
+      "dataPipeline": true
     },
     {
-      "id": "subway-entrances",
-      "sql": "SELECT the_geom_webmercator, cartodb_id FROM mta_subway_entrances"
+      "id": "mta-metronorth-rail-lines",
+      "sql": "SELECT the_geom_webmercator, cartodb_id, route_name FROM mta_metronorth_rail_lines",
+      "dataPipeline": true
+    },
+    {
+      "id": "path-rail-routes",
+      "sql": "SELECT the_geom_webmercator, route_shor FROM path_rail_routes",
+      "dataPipeline": true
+    },
+    {
+      "id": "station-envelope",
+      "sql": "SELECT cartodb_id as station_envelope_id, the_geom_webmercator, stat_name as station_name FROM mta_nyc_rail_station_envelope_dissolve",
+      "dataPipeline": true
+    },
+    {
+      "id": "station-envelope-point-on-surfaces",
+      "sql": "SELECT ST_PointOnSurface(the_geom_webmercator) as the_geom_webmercator, stat_name as station_name FROM mta_nyc_rail_station_envelope_dissolve",
+      "dataPipeline": true
     }
   ],
   "minzoom": 0,
   "meta": {
-    "description": "NYC Subway Lines and Stops - Originally Sourced from NYC DoITT GIS, combined with SI Railway data from Baruch College NYC Mass Transit Spatial Layers | Subway entrances from NYC Open Data",
+    "description": "NYC and Regional Transit Lines and Stops - Originally Sourced from NYC DoITT GIS, combined with SI Railway data from Baruch College NYC Mass Transit Spatial Layers | Subway entrances from NYC Open Data",
     "url": [
       "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_stops&format=SHP",
       "https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mta_subway_routes&format=SHP",


### PR DESCRIPTION
#### Summary
Used carto tables to create a new unified transit layer for use in ZoLa
<img width="1496" height="957" alt="Screenshot 2026-03-25 at 9 20 28 AM" src="https://github.com/user-attachments/assets/196b0a0c-d3f6-4f7a-b103-b41e05d2e8d1" />
<img width="1548" height="860" alt="Screenshot 2026-03-25 at 9 22 48 AM" src="https://github.com/user-attachments/assets/146cf6c2-9980-438a-8336-679395cc4865" />


#### Tasks/Bug Numbers
 - Fixes #388 
