### PR TITLE
Updated ZFA layer and data source

### DIFF
--- a/data/layer-groups/zoning-for-accessibility.json
+++ b/data/layer-groups/zoning-for-accessibility.json
@@ -38,14 +38,14 @@
       "highlightable": true,
       "clickable": true,
       "tooltipable": true,
-      "tooltipTemplate": "Transit-adjacent area - {{{station_na}}} Station",
+      "tooltipTemplate": "Transit-adjacent area",
       "style": {
         "id": "zfa-fill",
         "type": "fill",
         "source": "supporting-zoning",
         "source-layer": "zoning-for-accessibility",
         "paint": {
-          "fill-color": "rgba(218, 2, 200, 0.20)",
+          "fill-color": "rgba(218, 2, 200, 0.15)",
           "fill-antialias": true
         }
       }

--- a/data/sources/supporting-zoning.json
+++ b/data/sources/supporting-zoning.json
@@ -98,7 +98,7 @@
     },
     {
       "id": "zoning-for-accessibility",
-      "sql": "SELECT cartodb_id AS zfa_id, the_geom, station_na AS station_name, * FROM mta_rail_station_50ft_buffers",
+      "sql": "SELECT cartodb_id AS zfa_id, the_geom, * FROM mta_nyc_rail_station_buffer_dissolve",
       "dataPipeline": true
     }
   ],


### PR DESCRIPTION
#### Description
- replaced the existing ZFA station buffer with `mta_nyc_rail_station_buffer_dissolve table`
 - applied zfa  dissolved buffer layer fill color:  #`DA02C8 with 15% opacity => rgba(218, 2, 200, 0.20)`
 - updated the hover tooltip to “Transit-adjacent area”.
 - removed station names should be removed from the tooltip.
##### Before
<img width="778" height="717" alt="Screenshot 2026-03-31 at 11 04 09 AM" src="https://github.com/user-attachments/assets/d94f753b-85d3-4f39-8a53-f8141301c97c" />
 #####After
<img width="1097" height="753" alt="Screenshot 2026-03-31 at 11 03 31 AM" src="https://github.com/user-attachments/assets/8206e703-af60-4f66-8a27-03ad48ec1427" />

#####  Tickets
Closes #386 